### PR TITLE
Fix background report generation

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/ExcelReportController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/ExcelReportController.java
@@ -41,6 +41,9 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Resource;
+import javax.enterprise.concurrent.ManagedExecutorService;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.ejb.EJB;
@@ -110,6 +113,9 @@ public class ExcelReportController implements Serializable {
     @Inject
     ApplicationController applicationController;
 
+    @Resource
+    private ManagedExecutorService executorService;
+
     /**
      * Creates a new instance of ExcelReportController
      */
@@ -147,6 +153,7 @@ public class ExcelReportController implements Serializable {
                 return true;
             } else {
                 JsfUtil.addErrorMessage("Report Error. Please check details.");
+                updateOnFailure(storedQueryResult);
                 encountersWithComponents = null;
                 queriesWithCriteria = null;
                 return false;
@@ -158,6 +165,10 @@ public class ExcelReportController implements Serializable {
             return false;
         }
 
+    }
+
+    public CompletableFuture<Boolean> processReportAsync(StoredQueryResult storedQueryResult) {
+        return CompletableFuture.supplyAsync(() -> processReport(storedQueryResult), executorService);
     }
 
     public List<EncounterWithComponents> findEncountersWithComponents(List<Long> ids) {
@@ -250,6 +261,8 @@ public class ExcelReportController implements Serializable {
         } catch (IOException ex) {
             sqr.setErrorMessage("IO Exception. " + ex.getMessage());
             getStoreQueryResultFacade().edit(sqr);
+            updateOnFailure(sqr);
+            return null;
         }
 
         XSSFWorkbook workbook;
@@ -507,10 +520,12 @@ public class ExcelReportController implements Serializable {
         } catch (FileNotFoundException e) {
             sqr.setErrorMessage("IO Exception. " + e.getMessage());
             getStoreQueryResultFacade().edit(sqr);
+            updateOnFailure(sqr);
             return success;
         } catch (IOException e) {
             sqr.setErrorMessage("IO Exception. " + e.getMessage());
             getStoreQueryResultFacade().edit(sqr);
+            updateOnFailure(sqr);
             return success;
         }
 

--- a/src/main/java/lk/gov/health/phsp/bean/HospitalReportController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/HospitalReportController.java
@@ -787,12 +787,7 @@ public class HospitalReportController implements Serializable {
         setFromDate(sqr.getResultFrom());
         setToDate(sqr.getResultTo());
         JsfUtil.addSuccessMessage("Added to the Queue to Process");
-        boolean reportDone = getExcelReportController().processReport(sqr);
-        if (reportDone) {
-            JsfUtil.addSuccessMessage("Report Created. Please click the list button to list it.");
-        } else {
-            JsfUtil.addErrorMessage("Error");
-        }
+        getExcelReportController().processReportAsync(sqr);
 
     }
 

--- a/src/main/java/lk/gov/health/phsp/bean/ReportController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/ReportController.java
@@ -747,12 +747,7 @@ public class ReportController implements Serializable {
         setFromDate(sqr.getResultFrom());
         setToDate(sqr.getResultTo());
         JsfUtil.addSuccessMessage("Added to the Queue to Process");
-        boolean reportDone = getExcelReportController().processReport(sqr);
-        if (reportDone) {
-            JsfUtil.addSuccessMessage("Report Created. Please click the list button to list it.");
-        } else {
-            JsfUtil.addErrorMessage("Error");
-        }
+        getExcelReportController().processReportAsync(sqr);
 
     }
 


### PR DESCRIPTION
## Summary
- run Excel reports on a background executor
- mark failures correctly when report generation errors

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_688c3fffd6b0832f96b26bc3f8ce407c