### PR TITLE
Add first-time setup flow for fresh installations

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/WebUserController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/WebUserController.java
@@ -803,13 +803,69 @@ public class WebUserController implements Serializable {
         }
     }
 
-    private boolean thereAreUsersInTheSystem() {
+    public boolean thereAreUsersInTheSystem() {
         String jpql = "select w from WebUser w";
         WebUser u = getFacade().findFirstByJpql(jpql);
-        if (u == null) {
-            return false;
+        return u != null;
+    }
+
+    public String toSetupFirstAdmin() {
+        if (thereAreUsersInTheSystem()) {
+            return "/index";
         }
-        return true;
+        current = new WebUser();
+        password = "";
+        passwordReenter = "";
+        institutionName = "";
+        return "/setup";
+    }
+
+    public String setupFirstAdmin() {
+        if (thereAreUsersInTheSystem()) {
+            JsfUtil.addErrorMessage("Setup is only allowed on a fresh installation with no existing users.");
+            return "";
+        }
+        if (institutionName == null || institutionName.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please enter an Institution Name.");
+            return "";
+        }
+        if (current == null || current.getName() == null || current.getName().trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please enter a Username.");
+            return "";
+        }
+        if (password == null || password.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please enter a Password.");
+            return "";
+        }
+        if (!password.equals(passwordReenter)) {
+            JsfUtil.addErrorMessage("Passwords do not match.");
+            return "";
+        }
+        if (!passwordStrengthCheck(password)) {
+            return "";
+        }
+
+        Institution institution = new Institution();
+        institution.setName(institutionName.trim());
+        institution.setCreatedAt(new Date());
+        institutionFacade.create(institution);
+
+        current.setName(current.getName().toLowerCase().trim());
+        current.setWebUserPassword(commonController.hash(password));
+        current.setWebUserRole(WebUserRole.System_Administrator);
+        current.setCreatedAt(new Date());
+        current.setInstitution(institution);
+        getFacade().create(current);
+
+        loggedUser = current;
+        logged = true;
+        addWebUserPrivileges(current, getInitialPrivileges(WebUserRole.System_Administrator));
+        loggedUserPrivileges = userPrivilegeList(current);
+        webUserApplicationController.addToLoggedUsers(current.getName());
+        userTransactionController.recordTransaction("First Time Setup - Admin Created");
+
+        JsfUtil.addSuccessMessage("Setup complete. Welcome, " + current.getName() + "!");
+        return "/index";
     }
 
     private boolean checkLogin() {

--- a/src/main/webapp/resources/ezcomp/login.xhtml
+++ b/src/main/webapp/resources/ezcomp/login.xhtml
@@ -58,8 +58,18 @@
                                                                  value="Login"
                                                                  ajax="false"
                                                                  action="#{webUserController.login()}" >
-                                                </p:commandButton>    
+                                                </p:commandButton>
                                             </div>
+
+                                            <h:panelGroup rendered="#{not webUserController.thereAreUsersInTheSystem()}">
+                                                <div class="text-center border-top pt-3 mt-2">
+                                                    <p class="text-muted small mb-2">No users found. Is this a fresh installation?</p>
+                                                    <p:commandButton class="btn btn-outline-secondary m-1 w-75"
+                                                                     value="First Time Setup"
+                                                                     ajax="false"
+                                                                     action="#{webUserController.toSetupFirstAdmin()}"/>
+                                                </div>
+                                            </h:panelGroup>
 
 
 

--- a/src/main/webapp/setup.xhtml
+++ b/src/main/webapp/setup.xhtml
@@ -1,0 +1,120 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
+              rel="stylesheet"
+              integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+              crossorigin="anonymous"/>
+        <h:outputStylesheet library="css" name="login.css"/>
+        <title>cHIMS - First Time Setup</title>
+    </h:head>
+
+    <h:body>
+        <p:growl/>
+
+        <h:panelGroup rendered="#{webUserController.thereAreUsersInTheSystem()}">
+            <div class="container py-5 text-center">
+                <h3>Setup already completed.</h3>
+                <a href="index.xhtml">Go to Login</a>
+            </div>
+        </h:panelGroup>
+
+        <h:panelGroup rendered="#{not webUserController.thereAreUsersInTheSystem()}">
+            <section class="h-100 gradient-form" style="background-color: #eeee;">
+                <div class="container py-5 h-100">
+                    <div class="row d-flex justify-content-center align-items-center h-100">
+                        <div class="col-xl-10">
+                            <div class="card rounded-3 text-black">
+                                <div class="row g-0">
+                                    <div class="col-lg-6">
+                                        <div class="card-body p-md-5 mx-md-4">
+                                            <div class="text-center">
+                                                <h:graphicImage library="image" name="himslogo.png"
+                                                                style="width: 185px;" alt="logo"/>
+                                            </div>
+                                            <h5 class="text-center mt-3 mb-4">First Time Setup</h5>
+
+                                            <h:form>
+                                                <div class="form-outline mb-3">
+                                                    <label class="form-label m-1" for="institutionName">Institution Name</label>
+                                                    <p:inputText id="institutionName"
+                                                                 styleClass="w-100"
+                                                                 required="true"
+                                                                 requiredMessage="Please enter the institution name"
+                                                                 autocomplete="off"
+                                                                 value="#{webUserController.institutionName}"
+                                                                 class="form-control w-100"/>
+                                                </div>
+
+                                                <div class="form-outline mb-3">
+                                                    <label class="form-label m-1" for="adminUsername">Admin Username</label>
+                                                    <p:inputText id="adminUsername"
+                                                                 styleClass="w-100"
+                                                                 required="true"
+                                                                 requiredMessage="Please enter a username"
+                                                                 autocomplete="off"
+                                                                 value="#{webUserController.current.name}"
+                                                                 class="form-control w-100"/>
+                                                </div>
+
+                                                <div class="form-outline mb-3">
+                                                    <label class="form-label m-1" for="pwd">Password</label>
+                                                    <p:password id="pwd"
+                                                                toggleMask="true"
+                                                                required="true"
+                                                                requiredMessage="Please enter a password"
+                                                                value="#{webUserController.password}"
+                                                                class="form-control w-100"/>
+                                                    <small class="text-muted">Min 8 characters with uppercase, lowercase, digit, and special character.</small>
+                                                </div>
+
+                                                <div class="form-outline mb-4">
+                                                    <label class="form-label m-1" for="pwdConfirm">Confirm Password</label>
+                                                    <p:password id="pwdConfirm"
+                                                                toggleMask="true"
+                                                                required="true"
+                                                                requiredMessage="Please confirm your password"
+                                                                value="#{webUserController.passwordReenter}"
+                                                                class="form-control w-100"/>
+                                                </div>
+
+                                                <div class="text-center pt-1 mb-4">
+                                                    <p:commandButton class="btn m-1 w-75 btn"
+                                                                     value="Create Admin Account"
+                                                                     ajax="false"
+                                                                     action="#{webUserController.setupFirstAdmin()}"/>
+                                                </div>
+
+                                                <div class="text-center">
+                                                    <a href="index.xhtml" class="text-muted small">Back to Login</a>
+                                                </div>
+                                            </h:form>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6 d-flex align-items-center gradient-custom-2">
+                                        <div class="text-white px-3 py-4 p-md-5 mx-md-4">
+                                            <h4 class="mb-4">cHIMS</h4>
+                                            <p class="small mb-0 text-start">
+                                                This is a first-time setup. You are creating the initial administrator
+                                                account and institution for this cHIMS installation.<br/><br/>
+                                                The account you create here will have full System Administrator
+                                                privileges. Keep the credentials safe.
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </h:panelGroup>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary

Closes #350.

On a fresh cHIMS installation with an empty database there was no way to create the initial admin user and institution through the UI — the only workaround was a manual SQL INSERT.

- **`WebUserController`** — `thereAreUsersInTheSystem()` made public; new `toSetupFirstAdmin()` and `setupFirstAdmin()` methods added. `setupFirstAdmin()` creates the institution, a `System_Administrator` user with a hashed password, assigns all SA privileges, and logs the user in immediately.
- **`setup.xhtml`** — new standalone setup page (institution name + admin username/password + confirm). Guards itself: if users already exist it shows a message and links back to login.
- **`login.xhtml`** (ezcomp) — shows a **"First Time Setup"** button below the login form only when `thereAreUsersInTheSystem()` returns false (i.e. empty DB).

## Test plan

- [ ] Fresh DB (empty `WEBUSER` table): login page shows "First Time Setup" button.
- [ ] Click setup, fill institution name + username + password — admin account created, user is logged in as System Administrator.
- [ ] After setup, revisit `/setup.xhtml` directly — shows "Setup already completed" message.
- [ ] After setup, login page no longer shows "First Time Setup" button.
- [ ] Password strength validation (min 8 chars, upper, lower, digit, special) is enforced.
- [ ] Mismatched passwords show an error.
- [ ] Existing installation (users already in DB): setup button is hidden, `setupFirstAdmin()` rejects the call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)