### PR TITLE
Apple Notes-style checkboxes with Select All / Deselect All

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/AreaController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/AreaController.java
@@ -149,10 +149,10 @@ public class AreaController implements Serializable {
         return toListAreasForSysAdmin();
     }
 
-    public String deleteSelectedAreas() {
+    public void deleteSelectedAreas() {
         if (selectedAreas == null || selectedAreas.isEmpty()) {
             JsfUtil.addErrorMessage("No areas selected.");
-            return "";
+            return;
         }
         Date now = new Date();
         for (Area a : selectedAreas) {
@@ -161,9 +161,8 @@ public class AreaController implements Serializable {
             a.setRetiredBy(webUserController.getLoggedUser());
             getFacade().edit(a);
         }
-        items = null;
+        items = areaApplicationController.getAllAreas();
         selectedAreas = null;
-        return toListAreasForSysAdmin();
     }
 
     public List<Area> getSelectedAreas() { return selectedAreas; }

--- a/src/main/java/lk/gov/health/phsp/bean/AreaController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/AreaController.java
@@ -165,6 +165,14 @@ public class AreaController implements Serializable {
         selectedAreas = null;
     }
 
+    public void selectAllAreas() {
+        selectedAreas = new ArrayList<>(getItems());
+    }
+
+    public void deselectAllAreas() {
+        selectedAreas = new ArrayList<>();
+    }
+
     public List<Area> getSelectedAreas() { return selectedAreas; }
     public void setSelectedAreas(List<Area> selectedAreas) { this.selectedAreas = selectedAreas; }
 

--- a/src/main/java/lk/gov/health/phsp/bean/AreaController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/AreaController.java
@@ -63,6 +63,7 @@ public class AreaController implements Serializable {
     private List<Area> districts = null;
     private Area selected;
     private Area deleting;
+    private List<Area> selectedAreas;
     private UploadedFile file;
 
     @Inject
@@ -147,6 +148,26 @@ public class AreaController implements Serializable {
         deleting = null;
         return toListAreasForSysAdmin();
     }
+
+    public String deleteSelectedAreas() {
+        if (selectedAreas == null || selectedAreas.isEmpty()) {
+            JsfUtil.addErrorMessage("No areas selected.");
+            return "";
+        }
+        Date now = new Date();
+        for (Area a : selectedAreas) {
+            a.setRetired(true);
+            a.setRetiredAt(now);
+            a.setRetiredBy(webUserController.getLoggedUser());
+            getFacade().edit(a);
+        }
+        items = null;
+        selectedAreas = null;
+        return toListAreasForSysAdmin();
+    }
+
+    public List<Area> getSelectedAreas() { return selectedAreas; }
+    public void setSelectedAreas(List<Area> selectedAreas) { this.selectedAreas = selectedAreas; }
 
     public void reloadAreas(){
         areaApplicationController.reloadAreas();

--- a/src/main/java/lk/gov/health/phsp/bean/AreaImportService.java
+++ b/src/main/java/lk/gov/health/phsp/bean/AreaImportService.java
@@ -2,7 +2,9 @@ package lk.gov.health.phsp.bean;
 
 import java.io.ByteArrayInputStream;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import javax.ejb.Asynchronous;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
@@ -51,6 +53,14 @@ public class AreaImportService {
             int totalRows = Math.max(0, sheet.getRows() - startRow);
             progress[1] = totalRows;
 
+            // Build O(1) lookup set: "TYPE|name_lowercase"
+            Set<String> existingKeys = new HashSet<>();
+            for (Area a : areaApplicationController.getAllAreas()) {
+                if (a.getName() != null && a.getType() != null) {
+                    existingKeys.add(a.getType().name() + "|" + a.getName().toLowerCase());
+                }
+            }
+
             for (int i = startRow; i < sheet.getRows(); i++) {
                 progress[0]++;
 
@@ -79,7 +89,8 @@ public class AreaImportService {
                     continue;
                 }
 
-                if (areaApplicationController.getAreaByName(name, areaType) != null) {
+                String key = areaType.name() + "|" + name.toLowerCase();
+                if (existingKeys.contains(key)) {
                     progress[3]++;
                     continue;
                 }
@@ -111,7 +122,8 @@ public class AreaImportService {
                 area.setCreatedBy(createdBy);
 
                 try {
-                    areaFacade.create(area); // own transaction (REQUIRED on stateless)
+                    areaFacade.create(area);
+                    existingKeys.add(key); // prevent within-file duplicates
                     progress[2]++;
                 } catch (Exception ex) {
                     warnings.add("Row " + i + " (" + name + "): save failed — " + ex.getMessage());

--- a/src/main/java/lk/gov/health/phsp/bean/InstitutionController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/InstitutionController.java
@@ -656,6 +656,14 @@ public class InstitutionController implements Serializable {
         institutionApplicationController.resetAllInstitutions();
     }
 
+    public void selectAllInstitutions() {
+        selectedItems = new ArrayList<>(getItems());
+    }
+
+    public void deselectAllInstitutions() {
+        selectedItems = new ArrayList<>();
+    }
+
     public List<Institution> getSelectedItems() { return selectedItems; }
     public void setSelectedItems(List<Institution> selectedItems) { this.selectedItems = selectedItems; }
 

--- a/src/main/java/lk/gov/health/phsp/bean/InstitutionController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/InstitutionController.java
@@ -1,9 +1,11 @@
 package lk.gov.health.phsp.bean;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import lk.gov.health.phsp.entity.Institution;
 import lk.gov.health.phsp.bean.util.JsfUtil;
 import lk.gov.health.phsp.bean.util.JsfUtil.PersistAction;
@@ -48,6 +50,9 @@ public class InstitutionController implements Serializable {
     @EJB
     private AreaFacade areaFacade;
 
+    @EJB
+    private InstitutionImportService institutionImportService;
+
     @Inject
     private WebUserController webUserController;
 
@@ -78,6 +83,11 @@ public class InstitutionController implements Serializable {
     private String startMessage;
 
     private UploadedFile file;
+
+    private volatile boolean importRunning = false;
+    private int[] importProgress = new int[4];
+    private final boolean[] importRunningFlag = {false};
+    private List<String> importWarnings = Collections.synchronizedList(new ArrayList<>());
 
     public Institution getInstitutionById(Long id) {
         return getFacade().find(id);
@@ -514,96 +524,73 @@ public class InstitutionController implements Serializable {
         successMessage = "";
         failureMessage = "";
 
-        String newLine = "<br/>";
-
-        try {
-
-            File inputWorkbook;
-            Workbook w;
-            Cell cell;
-            InputStream in;
-
-            lk.gov.health.phsp.facade.util.JsfUtil.addSuccessMessage(file.getFileName());
-
-            try {
-                lk.gov.health.phsp.facade.util.JsfUtil.addSuccessMessage(file.getFileName());
-                in = file.getInputStream();
-                File f;
-                f = new File(Calendar.getInstance().getTimeInMillis() + file.getFileName());
-                FileOutputStream out = new FileOutputStream(f);
-                Integer read = 0;
-                byte[] bytes = new byte[1024];
-                while ((read = in.read(bytes)) != -1) {
-                    out.write(bytes, 0, read);
-                }
-                in.close();
-                out.flush();
-                out.close();
-
-                inputWorkbook = new File(f.getAbsolutePath());
-
-                successMessage += "File Uploaded Successfully." + newLine;
-
-                w = Workbook.getWorkbook(inputWorkbook);
-                Sheet sheet = w.getSheet(0);
-                int startRow = 1;
-
-                for (Integer i = startRow; i < sheet.getRows(); i++) {
-
-                    Institution newIns = new Institution();
-                    Institution newClinic = new Institution();
-                    String insName;
-                    String poi;
-
-                    cell = sheet.getCell(0, i);
-                    insName = cell.getContents();
-
-                    cell = sheet.getCell(1, i);
-                    poi = cell.getContents();
-
-                    newIns.setPoiNumber(poi);
-                    newIns.setName(institutionType.getLabel() + " " + insName);
-                    newIns.setInstitutionType(institutionType);
-                    newIns.setCreatedAt(new Date());
-                    newIns.setCreater(webUserController.getLoggedUser());
-                    newIns.setDistrict(district);
-                    newIns.setLastHin(0l);
-
-                    newIns.setParent(parent);
-                    newIns.setPdhsArea(pdhsArea);
-                    newIns.setProvince(province);
-                    newIns.setRdhsArea(rdhsArea);
-                    getFacade().create(newIns);
-
-                    newClinic.setName("HLC " + insName);
-                    newClinic.setInstitutionType(InstitutionType.Clinic);
-                    newClinic.setCreatedAt(new Date());
-                    newClinic.setCreater(webUserController.getLoggedUser());
-                    newClinic.setDistrict(district);
-                    newClinic.setLastHin(0l);
-                    newClinic.setPoiInstitution(newIns);
-                    newClinic.setParent(newIns);
-                    newClinic.setPdhsArea(pdhsArea);
-                    newClinic.setProvince(province);
-                    newClinic.setRdhsArea(rdhsArea);
-                    getFacade().create(newClinic);
-
-                    institutionApplicationController.setInstitutions(null);
-
-                }
-                lk.gov.health.phsp.facade.util.JsfUtil.addSuccessMessage("Completed. Please check success and failure messages.");
-                return "";
-            } catch (IOException | BiffException ex) {
-                lk.gov.health.phsp.facade.util.JsfUtil.addErrorMessage(ex.getMessage());
-                failureMessage += "Error. " + ex.getMessage() + ". Aborting the process." + newLine;
-                return "";
-            }
-        } catch (IndexOutOfBoundsException e) {
-            failureMessage += "Error. " + e.getMessage() + ". Aborting the process." + newLine;
+        if (file == null) {
+            JsfUtil.addErrorMessage("No file selected.");
+            return "";
+        }
+        if (institutionType == null) {
+            JsfUtil.addErrorMessage("Please select an Institution Type.");
+            return "";
+        }
+        if (importRunning) {
+            JsfUtil.addErrorMessage("Import already in progress.");
             return "";
         }
 
+        try {
+            InputStream in = file.getInputStream();
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            byte[] buf = new byte[1024];
+            int read;
+            while ((read = in.read(buf)) != -1) {
+                baos.write(buf, 0, read);
+            }
+            in.close();
+
+            importProgress = new int[4];
+            importWarnings = Collections.synchronizedList(new ArrayList<>());
+            importRunningFlag[0] = true;
+            importRunning = true;
+
+            institutionImportService.runImport(
+                    baos.toByteArray(),
+                    webUserController.getLoggedUser().getId(),
+                    institutionType,
+                    parent   != null ? parent.getId()   : null,
+                    province != null ? province.getId() : null,
+                    pdhsArea != null ? pdhsArea.getId() : null,
+                    district != null ? district.getId() : null,
+                    rdhsArea != null ? rdhsArea.getId() : null,
+                    importProgress, importRunningFlag, importWarnings);
+
+            return "";
+        } catch (IOException ex) {
+            importRunning = false;
+            JsfUtil.addErrorMessage(ex.getMessage());
+            failureMessage = "Error reading file: " + ex.getMessage();
+            return "";
+        }
     }
+
+    public boolean isImportRunning() {
+        if (importRunning && !importRunningFlag[0]) {
+            importRunning = false;
+        }
+        return importRunning;
+    }
+
+    public int getImportProcessed() { return importProgress[0]; }
+    public int getImportTotal()     { return importProgress[1]; }
+    public int getImportCreated()   { return importProgress[2]; }
+    public int getImportSkipped()   { return importProgress[3]; }
+
+    public int getImportPercent() {
+        int total = importProgress[1];
+        if (total <= 0) return 0;
+        return (int) Math.min(importProgress[0] * 100L / total, 100);
+    }
+
+    public List<String> getImportWarnings() { return importWarnings; }
     
     public void saveOrUpdateInstitution() {
         if (selected == null) {

--- a/src/main/java/lk/gov/health/phsp/bean/InstitutionController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/InstitutionController.java
@@ -66,6 +66,7 @@ public class InstitutionController implements Serializable {
     private List<Institution> items = null;
     private Institution selected;
     private Institution deleting;
+    private List<Institution> selectedItems;
     private List<Institution> myClinics;
     private List<Area> gnAreasOfSelected;
     private Area area;
@@ -641,6 +642,22 @@ public class InstitutionController implements Serializable {
             items = null;    // Invalidate list of items to trigger re-query.
         }
     }
+
+    public void deleteSelectedItems() {
+        if (selectedItems == null || selectedItems.isEmpty()) {
+            JsfUtil.addErrorMessage("No institutions selected.");
+            return;
+        }
+        for (Institution ins : selectedItems) {
+            getFacade().remove(ins);
+        }
+        items = null;
+        selectedItems = null;
+        institutionApplicationController.resetAllInstitutions();
+    }
+
+    public List<Institution> getSelectedItems() { return selectedItems; }
+    public void setSelectedItems(List<Institution> selectedItems) { this.selectedItems = selectedItems; }
 
     public List<Institution> getItems() {
         if (items == null) {

--- a/src/main/java/lk/gov/health/phsp/bean/InstitutionImportService.java
+++ b/src/main/java/lk/gov/health/phsp/bean/InstitutionImportService.java
@@ -1,0 +1,157 @@
+package lk.gov.health.phsp.bean;
+
+import java.io.ByteArrayInputStream;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.ejb.Asynchronous;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.inject.Inject;
+import jxl.Cell;
+import jxl.Sheet;
+import jxl.Workbook;
+import lk.gov.health.phsp.entity.Area;
+import lk.gov.health.phsp.entity.Institution;
+import lk.gov.health.phsp.entity.WebUser;
+import lk.gov.health.phsp.enums.InstitutionType;
+import lk.gov.health.phsp.facade.AreaFacade;
+import lk.gov.health.phsp.facade.InstitutionFacade;
+import lk.gov.health.phsp.facade.WebUserFacade;
+
+@Stateless
+public class InstitutionImportService {
+
+    @EJB
+    private InstitutionFacade institutionFacade;
+
+    @EJB
+    private AreaFacade areaFacade;
+
+    @EJB
+    private WebUserFacade webUserFacade;
+
+    @Inject
+    private InstitutionApplicationController institutionApplicationController;
+
+    /**
+     * Async import — no outer transaction; each facade.create() is its own transaction.
+     * Areas and WebUser are looked up by ID inside each create via the facade (REQUIRED).
+     */
+    @Asynchronous
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public void runImport(byte[] fileData,
+                          Long createdById,
+                          InstitutionType institutionType,
+                          Long parentId,
+                          Long provinceId,
+                          Long pdhsAreaId,
+                          Long districtId,
+                          Long rdhsAreaId,
+                          int[] progress,
+                          boolean[] running,
+                          List<String> warnings) {
+        try {
+            // Fetch managed references once (each call is REQUIRED — own transaction)
+            WebUser   createdBy = webUserFacade.find(createdById);
+            Institution parent  = parentId  != null ? institutionFacade.find(parentId)  : null;
+            Area province       = provinceId != null ? areaFacade.find(provinceId)  : null;
+            Area pdhsArea       = pdhsAreaId != null ? areaFacade.find(pdhsAreaId)  : null;
+            Area district       = districtId != null ? areaFacade.find(districtId)  : null;
+            Area rdhsArea       = rdhsAreaId != null ? areaFacade.find(rdhsAreaId)  : null;
+
+            // O(1) duplicate check
+            Set<String> existingNames = new HashSet<>();
+            for (Institution ins : institutionApplicationController.getInstitutions()) {
+                if (ins.getName() != null) {
+                    existingNames.add(ins.getName().toLowerCase());
+                }
+            }
+
+            Workbook w = Workbook.getWorkbook(new ByteArrayInputStream(fileData));
+            Sheet sheet = w.getSheet(0);
+            progress[1] = Math.max(0, sheet.getRows() - 1);
+
+            for (int i = 1; i < sheet.getRows(); i++) {
+                progress[0]++;
+
+                String insName = getCellValue(sheet, 0, i);
+                String poi     = getCellValue(sheet, 1, i);
+
+                if (insName.isEmpty()) {
+                    progress[3]++;
+                    continue;
+                }
+
+                String fullName = institutionType.getLabel() + " " + insName;
+                String hlcName  = "HLC " + insName;
+
+                if (existingNames.contains(fullName.toLowerCase())) {
+                    progress[3]++;
+                    continue;
+                }
+
+                try {
+                    Institution newIns = buildInstitution(
+                            fullName, poi.isEmpty() ? null : poi,
+                            institutionType, createdBy,
+                            parent, province, pdhsArea, district, rdhsArea);
+                    institutionFacade.create(newIns);
+                    existingNames.add(fullName.toLowerCase());
+
+                    Institution newClinic = buildInstitution(
+                            hlcName, null,
+                            InstitutionType.Clinic, createdBy,
+                            newIns, province, pdhsArea, district, rdhsArea);
+                    newClinic.setPoiInstitution(newIns);
+                    institutionFacade.create(newClinic);
+                    existingNames.add(hlcName.toLowerCase());
+
+                    progress[2]++;
+                } catch (Exception ex) {
+                    warnings.add("Row " + i + " (" + insName + "): save failed — " + ex.getMessage());
+                    progress[3]++;
+                }
+            }
+
+        } catch (Exception ex) {
+            warnings.add("Fatal error: " + ex.getMessage());
+        } finally {
+            running[0] = false;
+            try {
+                institutionApplicationController.resetAllInstitutions();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    private Institution buildInstitution(String name, String poi, InstitutionType type,
+                                          WebUser createdBy, Institution parent,
+                                          Area province, Area pdhsArea, Area district, Area rdhsArea) {
+        Institution ins = new Institution();
+        ins.setName(name);
+        ins.setPoiNumber(poi);
+        ins.setInstitutionType(type);
+        ins.setCreatedAt(new Date());
+        ins.setCreater(createdBy);
+        ins.setLastHin(0L);
+        ins.setParent(parent);
+        ins.setProvince(province);
+        ins.setPdhsArea(pdhsArea);
+        ins.setDistrict(district);
+        ins.setRdhsArea(rdhsArea);
+        return ins;
+    }
+
+    private String getCellValue(Sheet sheet, int col, int row) {
+        try {
+            Cell cell = sheet.getCell(col, row);
+            return cell == null ? "" : cell.getContents().trim();
+        } catch (Exception e) {
+            return "";
+        }
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/bean/ItemController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/ItemController.java
@@ -1113,6 +1113,14 @@ public class ItemController implements Serializable {
         JsfUtil.addSuccessMessage("Selected items deleted.");
     }
 
+    public void selectAllDictionaryItems() {
+        selectedItems = new ArrayList<>(getItems());
+    }
+
+    public void deselectAllDictionaryItems() {
+        selectedItems = new ArrayList<>();
+    }
+
     public List<Item> getSelectedItems() { return selectedItems; }
     public void setSelectedItems(List<Item> selectedItems) { this.selectedItems = selectedItems; }
 

--- a/src/main/java/lk/gov/health/phsp/bean/ItemController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/ItemController.java
@@ -65,6 +65,7 @@ public class ItemController implements Serializable {
 
     private List<Item> items = null;
     private Item selected;
+    private List<Item> selectedItems;
     private Item selectedParent;
     private Item removingItem;
     private List<Item> titles;
@@ -1093,6 +1094,27 @@ public class ItemController implements Serializable {
             }
         }
     }
+
+    public void destroySelected() {
+        if (selectedItems == null || selectedItems.isEmpty()) {
+            JsfUtil.addErrorMessage("No items selected.");
+            return;
+        }
+        Date now = new Date();
+        for (Item i : selectedItems) {
+            i.setRetired(true);
+            i.setRetiredAt(now);
+            i.setRetiredBy(webUserController.getLoggedUser());
+            getFacade().edit(i);
+        }
+        items = null;
+        selectedItems = null;
+        itemApplicationController.invalidateItems();
+        JsfUtil.addSuccessMessage("Selected items deleted.");
+    }
+
+    public List<Item> getSelectedItems() { return selectedItems; }
+    public void setSelectedItems(List<Item> selectedItems) { this.selectedItems = selectedItems; }
 
     public void retireAllDictionaryItems() {
         String j = "select i from Item i where i.retired=false and i.itemType=:it";

--- a/src/main/webapp/area/import_areas.xhtml
+++ b/src/main/webapp/area/import_areas.xhtml
@@ -60,33 +60,38 @@
 
                 <!-- Progress form — polled every 2 seconds while import is running -->
                 <h:form id="progressForm">
-                    <p:panel id="progressPanel" rendered="#{areaController.importRunning}" style="margin-top:1rem;">
-                        <f:facet name="header">Importing Areas...</f:facet>
-                        <p:progressBar value="#{areaController.importPercent}"
-                                       labelTemplate="{value}%"
-                                       style="margin-bottom:0.8rem;"/>
-                        <p>
-                            <strong>Processed:</strong> #{areaController.importProcessed} of #{areaController.importTotal} rows
-                        </p>
-                        <p>
-                            <strong>Created:</strong> #{areaController.importCreated} &#160;
-                            <strong>Skipped:</strong> #{areaController.importSkipped}
-                        </p>
-                    </p:panel>
+                    <!-- Always-present wrapper so AJAX update always has a DOM target -->
+                    <h:panelGroup id="progressPanel" layout="block">
+                        <p:panel rendered="#{areaController.importRunning}" style="margin-top:1rem;">
+                            <f:facet name="header">Importing Areas...</f:facet>
+                            <p:progressBar value="#{areaController.importPercent}"
+                                           labelTemplate="{value}%"
+                                           style="margin-bottom:0.8rem;"/>
+                            <p>
+                                <strong>Processed:</strong> #{areaController.importProcessed} of #{areaController.importTotal} rows
+                            </p>
+                            <p>
+                                <strong>Created:</strong> #{areaController.importCreated} &#160;
+                                <strong>Skipped:</strong> #{areaController.importSkipped}
+                            </p>
+                        </p:panel>
+                    </h:panelGroup>
 
-                    <p:panel id="donePanel" rendered="#{!areaController.importRunning and areaController.importTotal gt 0}" style="margin-top:1rem;">
-                        <f:facet name="header">Import Complete</f:facet>
-                        <p style="color:green;">
-                            <strong>Created:</strong> #{areaController.importCreated} &#160;
-                            <strong>Skipped:</strong> #{areaController.importSkipped} &#160;
-                            <strong>Total rows processed:</strong> #{areaController.importProcessed}
-                        </p>
-                        <p:dataList value="#{areaController.importWarnings}" var="w"
-                                    rendered="#{not empty areaController.importWarnings}"
-                                    style="color:orange; margin-top:0.5rem;">
-                            <h:outputText value="#{w}"/>
-                        </p:dataList>
-                    </p:panel>
+                    <h:panelGroup id="donePanel" layout="block">
+                        <p:panel rendered="#{!areaController.importRunning and areaController.importTotal gt 0}" style="margin-top:1rem;">
+                            <f:facet name="header">Import Complete</f:facet>
+                            <p style="color:green;">
+                                <strong>Created:</strong> #{areaController.importCreated} &#160;
+                                <strong>Skipped:</strong> #{areaController.importSkipped} &#160;
+                                <strong>Total rows processed:</strong> #{areaController.importProcessed}
+                            </p>
+                            <p:dataList value="#{areaController.importWarnings}" var="w"
+                                        rendered="#{not empty areaController.importWarnings}"
+                                        style="color:orange; margin-top:0.5rem;">
+                                <h:outputText value="#{w}"/>
+                            </p:dataList>
+                        </p:panel>
+                    </h:panelGroup>
 
                     <p:poll id="importPoll"
                             interval="2"

--- a/src/main/webapp/area/list.xhtml
+++ b/src/main/webapp/area/list.xhtml
@@ -22,9 +22,10 @@
                         <p:dataExporter target="datalist" type="xls" fileName="areas"/>
                     </p:commandButton>
 
-                    <p:commandButton ajax="false" value="Delete Selected"
+                    <p:commandButton value="Delete Selected"
                                      style="margin-right:0.5rem;"
                                      action="#{areaController.deleteSelectedAreas()}"
+                                     update="datalist"
                                      onclick="return confirm('Are you sure you want to delete the selected areas? This cannot be undone.');"/>
 
                     <p:dataTable id="datalist" value="#{areaController.items}"
@@ -36,45 +37,48 @@
                                  rows="10"
                                  rowsPerPageTemplate="10,20,30,40,50">
 
+                        <p:ajax event="rowSelect"/>
+                        <p:ajax event="rowUnselect"/>
+
                         <p:column selectionMode="multiple" style="width:2.5rem; text-align:center;" exportable="false"/>
 
-                        <p:column sortBy="#{item.type}">
+                        <p:column sortBy="#{item.type}" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="#{bundleClinical.ListAreaTitle_type}"/>
                             </f:facet>
                             <h:outputText value="#{item.type}"/>
                         </p:column>
-                        <p:column sortBy="#{item.name}" filterBy="#{item.name}" filterMatchMode="contains">
+                        <p:column sortBy="#{item.name}" filterBy="#{item.name}" filterMatchMode="contains" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="#{bundleClinical.ListAreaTitle_name}"/>
                             </f:facet>
                             <h:outputText value="#{item.name}"/>
                         </p:column>
-                        <p:column sortBy="#{item.code}" filterBy="#{item.code}">
+                        <p:column sortBy="#{item.code}" filterBy="#{item.code}" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="#{bundleClinical.ListAreaTitle_code}"/>
                             </f:facet>
                             <h:outputText value="#{item.code}"/>
                         </p:column>
-                        <p:column sortBy="#{item.areauid}" filterBy="#{item.areauid}" filterMatchMode="contains">
+                        <p:column sortBy="#{item.areauid}" filterBy="#{item.areauid}" filterMatchMode="contains" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="ID"/>
                             </f:facet>
                             <h:outputText value="#{item.areauid}"/>
                         </p:column>
-                        <p:column sortBy="#{item.parentArea.name}" filterBy="#{item.parentArea.name}" filterMatchMode="contains">
+                        <p:column sortBy="#{item.parentArea.name}" filterBy="#{item.parentArea.name}" filterMatchMode="contains" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="#{bundleClinical.ListAreaTitle_parentArea}"/>
                             </f:facet>
                             <h:outputText value="#{item.parentArea.name}"/>
                         </p:column>
-                        <p:column sortBy="#{item.district.name}" filterBy="#{item.district.name}" filterMatchMode="contains">
+                        <p:column sortBy="#{item.district.name}" filterBy="#{item.district.name}" filterMatchMode="contains" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="District"/>
                             </f:facet>
                             <h:outputText value="#{item.district.name}"/>
                         </p:column>
-                        <p:column headerText="Actions" exportable="false">
+                        <p:column headerText="Actions" exportable="false" onclick="event.stopPropagation()">
                             <p:commandButton ajax="false" class="m-1" value="Edit"
                                              action="#{areaController.toEditAreaForSysAdmin()}">
                                 <f:setPropertyActionListener value="#{item}" target="#{areaController.selected}"/>

--- a/src/main/webapp/area/list.xhtml
+++ b/src/main/webapp/area/list.xhtml
@@ -22,23 +22,36 @@
                         <p:dataExporter target="datalist" type="xls" fileName="areas"/>
                     </p:commandButton>
 
+                    <p:commandButton value="Select All"
+                                     style="margin-right:0.5rem;"
+                                     action="#{areaController.selectAllAreas()}"
+                                     update="datalist"
+                                     process="@this"/>
+
+                    <p:commandButton value="Deselect All"
+                                     style="margin-right:0.5rem;"
+                                     action="#{areaController.deselectAllAreas()}"
+                                     process="@this"
+                                     oncomplete="PF('areaTable').unselectAllRows();"/>
+
                     <p:commandButton value="Delete Selected"
                                      style="margin-right:0.5rem;"
                                      action="#{areaController.deleteSelectedAreas()}"
                                      update="datalist"
                                      onclick="return confirm('Are you sure you want to delete the selected areas? This cannot be undone.');"/>
 
-                    <p:dataTable id="datalist" value="#{areaController.items}"
+                    <p:dataTable id="datalist" widgetVar="areaTable" value="#{areaController.items}"
                                  var="item"
                                  rowKey="#{item.id}"
-                                 selectionMode="multiple"
                                  selection="#{areaController.selectedAreas}"
+                                 styleClass="apple-checkbox-table"
                                  paginator="true"
                                  rows="10"
                                  rowsPerPageTemplate="10,20,30,40,50">
 
-                        <p:ajax event="rowSelect"/>
-                        <p:ajax event="rowUnselect"/>
+                        <p:ajax event="rowSelectCheckbox"/>
+                        <p:ajax event="rowUnselectCheckbox"/>
+                        <p:ajax event="toggleSelect"/>
 
                         <p:column selectionMode="multiple" style="width:2.5rem; text-align:center;" exportable="false"/>
 

--- a/src/main/webapp/area/list.xhtml
+++ b/src/main/webapp/area/list.xhtml
@@ -25,8 +25,7 @@
                     <p:commandButton ajax="false" value="Delete Selected"
                                      style="margin-right:0.5rem;"
                                      action="#{areaController.deleteSelectedAreas()}"
-                                     onclick="return confirm('Are you sure you want to delete the selected areas? This cannot be undone.');"
-                                     disabled="#{empty areaController.selectedAreas}"/>
+                                     onclick="return confirm('Are you sure you want to delete the selected areas? This cannot be undone.');"/>
 
                     <p:dataTable id="datalist" value="#{areaController.items}"
                                  var="item"

--- a/src/main/webapp/area/list.xhtml
+++ b/src/main/webapp/area/list.xhtml
@@ -11,76 +11,85 @@
         <ui:composition template="./index.xhtml">
 
             <ui:define name="insTopic">
-                <p:outputLabel value="Area List" ></p:outputLabel>
+                <p:outputLabel value="Area List"/>
             </ui:define>
 
             <ui:define name="insContents">
 
                 <h:form id="AreaListForm">
 
-                    <p:commandButton ajax="false" value="Download" >
-                        <p:dataExporter target="datalist" type="xls" fileName="areas" ></p:dataExporter>
+                    <p:commandButton ajax="false" value="Download" style="margin-right:0.5rem;">
+                        <p:dataExporter target="datalist" type="xls" fileName="areas"/>
                     </p:commandButton>
-                    
-                    <p:dataTable id="datalist" value="#{areaController.items}" 
-                                 var="item" 
+
+                    <p:commandButton ajax="false" value="Delete Selected"
+                                     style="margin-right:0.5rem;"
+                                     action="#{areaController.deleteSelectedAreas()}"
+                                     onclick="return confirm('Are you sure you want to delete the selected areas? This cannot be undone.');"
+                                     disabled="#{empty areaController.selectedAreas}"/>
+
+                    <p:dataTable id="datalist" value="#{areaController.items}"
+                                 var="item"
                                  rowKey="#{item.id}"
+                                 selectionMode="multiple"
+                                 selection="#{areaController.selectedAreas}"
                                  paginator="true"
                                  rows="10"
-                                 rowsPerPageTemplate="10,20,30,40,50"
-                                 >
+                                 rowsPerPageTemplate="10,20,30,40,50">
+
+                        <p:column selectionMode="multiple" style="width:2.5rem; text-align:center;" exportable="false"/>
+
                         <p:column sortBy="#{item.type}">
                             <f:facet name="header">
                                 <h:outputText value="#{bundleClinical.ListAreaTitle_type}"/>
                             </f:facet>
                             <h:outputText value="#{item.type}"/>
                         </p:column>
-                        <p:column sortBy="#{item.name}"  filterBy="#{item.name}" filterMatchMode="contains">
+                        <p:column sortBy="#{item.name}" filterBy="#{item.name}" filterMatchMode="contains">
                             <f:facet name="header">
                                 <h:outputText value="#{bundleClinical.ListAreaTitle_name}"/>
                             </f:facet>
                             <h:outputText value="#{item.name}"/>
                         </p:column>
-                        <p:column sortBy="#{item.code}" filterBy="#{item.code}" >
-                            <f:facet name="header" >
+                        <p:column sortBy="#{item.code}" filterBy="#{item.code}">
+                            <f:facet name="header">
                                 <h:outputText value="#{bundleClinical.ListAreaTitle_code}"/>
                             </f:facet>
                             <h:outputText value="#{item.code}"/>
                         </p:column>
                         <p:column sortBy="#{item.areauid}" filterBy="#{item.areauid}" filterMatchMode="contains">
-                            <f:facet name="header" >
+                            <f:facet name="header">
                                 <h:outputText value="ID"/>
                             </f:facet>
                             <h:outputText value="#{item.areauid}"/>
                         </p:column>
-                        <p:column  sortBy="#{item.parentArea.name}" filterBy="#{item.parentArea.name}" filterMatchMode="contains">
+                        <p:column sortBy="#{item.parentArea.name}" filterBy="#{item.parentArea.name}" filterMatchMode="contains">
                             <f:facet name="header">
                                 <h:outputText value="#{bundleClinical.ListAreaTitle_parentArea}"/>
                             </f:facet>
                             <h:outputText value="#{item.parentArea.name}"/>
                         </p:column>
-                        <p:column  sortBy="#{item.district.name}" filterBy="#{item.district.name}" filterMatchMode="contains">
+                        <p:column sortBy="#{item.district.name}" filterBy="#{item.district.name}" filterMatchMode="contains">
                             <f:facet name="header">
                                 <h:outputText value="District"/>
                             </f:facet>
                             <h:outputText value="#{item.district.name}"/>
                         </p:column>
-                        <p:column headerText="Actions" exportable="false" >
-                            <p:commandButton ajax="false" class="m-1" value="Edit" action="#{areaController.toEditAreaForSysAdmin()}" >
-                                <f:setPropertyActionListener value="#{item}" target="#{areaController.selected}" ></f:setPropertyActionListener>
+                        <p:column headerText="Actions" exportable="false">
+                            <p:commandButton ajax="false" class="m-1" value="Edit"
+                                             action="#{areaController.toEditAreaForSysAdmin()}">
+                                <f:setPropertyActionListener value="#{item}" target="#{areaController.selected}"/>
                             </p:commandButton>
-                            <p:commandButton ajax="false" class="m-1" value="Delete" action="#{areaController.deleteAreaForSysAdmin()}"
-                                             onclick="return confirm('Are you sure?')">
-                                <f:setPropertyActionListener 
-                                    value="#{item}" 
-                                    target="#{areaController.deleting}" ></f:setPropertyActionListener>
+                            <p:commandButton ajax="false" class="m-1" value="Delete"
+                                             action="#{areaController.deleteAreaForSysAdmin()}"
+                                             onclick="return confirm('Are you sure you want to delete this area?');">
+                                <f:setPropertyActionListener value="#{item}" target="#{areaController.deleting}"/>
                             </p:commandButton>
                         </p:column>
-                        
+
                     </p:dataTable>
 
                 </h:form>
-
 
             </ui:define>
 

--- a/src/main/webapp/institution/import.xhtml
+++ b/src/main/webapp/institution/import.xhtml
@@ -10,86 +10,119 @@
         <ui:composition template="/institution/index.xhtml">
             <ui:define name="insContents">
 
-                <h:form id="InstitutionCreateForm" style="padding-top: 1rem;"  enctype="multipart/form-data">
+                <!-- Upload form — hidden while import is running -->
+                <h:form enctype="multipart/form-data" rendered="#{!institutionController.importRunning}">
 
-                    <h:panelGroup id="display">
-                        <p:commandButton ajax="false" 
-                                         action="#{institutionController.importInstitutions()}" 
-                                         value="Import"/>
+                    <p:panel header="Instructions" style="margin-bottom:1rem;">
+                        <p>Upload an XLS file with institution names. Column A = Institution Name, Column B = POI Number.</p>
+                        <p>Each row creates one institution of the selected type plus an HLC Clinic linked to it.</p>
+                        <p>Duplicates (matching name) are skipped automatically.</p>
+                    </p:panel>
 
+                    <p:panelGrid columns="2" style="margin-bottom:1rem;">
 
-                        <p>Start Row - 1</p>
-                        <p>Institution Name Column - 1 / A</p><!-- comment -->
-                        <p>POI Column - 2 / B</p>
+                        <p:outputLabel value="File (.xls only)" for="file"/>
+                        <p:fileUpload id="file" value="#{institutionController.file}" mode="simple"/>
 
-                        <p:panelGrid columns="2">
-                            <p:outputLabel value="File" for="file" />
-                            <p:fileUpload id="file" value="#{institutionController.file}" mode="simple"/>
+                        <p:outputLabel value="Type:" for="institutionType"/>
+                        <p:selectOneMenu id="institutionType"
+                                         value="#{institutionController.institutionType}"
+                                         required="true">
+                            <f:selectItems value="#{applicationController.institutionTypes}"
+                                           var="institutionTypes"
+                                           itemValue="#{institutionTypes}"
+                                           itemLabel="#{institutionTypes.label}"/>
+                        </p:selectOneMenu>
 
-                            <p:outputLabel value="Type:" for="institutionType" />
-                            <p:selectOneMenu id="institutionType" 
-                                             value="#{institutionController.institutionType}" title="InstitutionType" 
-                                             required="true" >
-                                <f:selectItems value="#{applicationController.institutionTypes}" 
-                                               var="institutionTypes"
-                                               itemValue="#{institutionTypes}"
+                        <p:outputLabel value="Parent:" for="parent"/>
+                        <p:autoComplete id="parent" value="#{institutionController.parent}"
+                                        required="true"
+                                        completeMethod="#{institutionController.completeInstitutions}"
+                                        var="i" itemLabel="#{i.name}" itemValue="#{i}"
+                                        forceSelection="true" maxResults="15" minQueryLength="3"/>
 
-                                               itemLabel="#{institutionTypes.label}"></f:selectItems>
-                            </p:selectOneMenu>
+                        <p:outputLabel value="Province:" for="province"/>
+                        <p:autoComplete id="province" value="#{institutionController.province}"
+                                        completeMethod="#{areaController.completeProvinces}"
+                                        required="true"
+                                        var="province" itemLabel="#{province.name}" itemValue="#{province}"
+                                        maxResults="15" forceSelection="true" minQueryLength="3"/>
 
+                        <p:outputLabel value="PDHS Area:" for="pdhsArea"/>
+                        <p:autoComplete id="pdhsArea" value="#{institutionController.pdhsArea}"
+                                        completeMethod="#{areaController.completePdhsAreas}"
+                                        required="true"
+                                        var="pdhsArea" itemLabel="#{pdhsArea.name}" itemValue="#{pdhsArea}"
+                                        maxResults="15" forceSelection="true" minQueryLength="3"/>
 
-                            <p:outputLabel value="Parent:" for="parent" />
-                            <p:autoComplete  id="parent" value="#{institutionController.parent}" 
-                                             required="true"
-                                             completeMethod="#{institutionController.completeInstitutions}"
-                                             var="i" itemLabel="#{i.name}" itemValue="#{i}" forceSelection="true"
-                                             maxResults="15" minQueryLength="3">
-                            </p:autoComplete >
+                        <p:outputLabel value="District:" for="district"/>
+                        <p:autoComplete id="district" value="#{institutionController.district}"
+                                        completeMethod="#{areaController.completeDistricts}"
+                                        required="true"
+                                        var="district" itemLabel="#{district.name}" itemValue="#{district}"
+                                        maxResults="15" forceSelection="true" minQueryLength="3"/>
 
+                        <p:outputLabel value="RDHS Area:" for="rdhsArea"/>
+                        <p:autoComplete id="rdhsArea" value="#{institutionController.rdhsArea}"
+                                        completeMethod="#{areaController.completeRdhsAreas}"
+                                        required="true"
+                                        var="rdhsArea" itemLabel="#{rdhsArea.name}" itemValue="#{rdhsArea}"
+                                        maxResults="15" forceSelection="true" minQueryLength="3"/>
 
+                    </p:panelGrid>
 
-                            <p:outputLabel value="Province:" for="province" />
-                            <p:autoComplete id="province" value="#{institutionController.province}"
-                                            completeMethod="#{areaController.completeProvinces}" required="true"
-                                            var="province" itemLabel="#{province.name}" itemValue="#{province}"
-                                            maxResults="15" forceSelection="true"
-                                            minQueryLength="3">
-                            </p:autoComplete>
+                    <p:commandButton ajax="false" value="Import Institutions"
+                                     action="#{institutionController.importInstitutions()}"/>
 
-                            <p:outputLabel value="PDHS Area:" for="pdhsArea" />
-                            <p:autoComplete id="pdhsArea" value="#{institutionController.pdhsArea}"
-                                            completeMethod="#{areaController.completePdhsAreas}"
-                                            required="true"
-                                            var="pdhsArea" itemLabel="#{pdhsArea.name}" itemValue="#{pdhsArea}"
-                                            maxResults="15" forceSelection="true"
-                                            minQueryLength="3">
-                            </p:autoComplete>
-
-                            <p:outputLabel value="District:" for="district" />
-                            <p:autoComplete id="district" value="#{institutionController.district}"
-                                            completeMethod="#{areaController.completeDistricts}"
-                                            required="true"
-                                            var="district" itemLabel="#{district.name}" itemValue="#{district}"
-                                            maxResults="15" forceSelection="true"
-                                            minQueryLength="3">
-                            </p:autoComplete>
-
-                            <p:outputLabel value="RDHS Area:" for="rdhsArea" />
-                            <p:autoComplete id="rdhsArea" value="#{institutionController.rdhsArea}"
-                                            completeMethod="#{areaController.completeRdhsAreas}"
-                                            required="true"
-                                            var="rdhsArea" itemLabel="#{rdhsArea.name}" itemValue="#{rdhsArea}"
-                                            maxResults="15" forceSelection="true"
-                                            minQueryLength="3">
-                            </p:autoComplete>
-
-
-                        </p:panelGrid>                            
-
-                    </h:panelGroup>
+                    <p:panel rendered="#{not empty institutionController.failureMessage}"
+                             header="Error" style="margin-top:1rem;">
+                        <h:outputText value="#{institutionController.failureMessage}" escape="false"/>
+                    </p:panel>
                 </h:form>
+
+                <!-- Progress form — polled every 2 seconds while import runs -->
+                <h:form id="progressForm">
+                    <h:panelGroup id="progressPanel" layout="block">
+                        <p:panel rendered="#{institutionController.importRunning}" style="margin-top:1rem;">
+                            <f:facet name="header">Importing Institutions...</f:facet>
+                            <p:progressBar value="#{institutionController.importPercent}"
+                                           labelTemplate="{value}%"
+                                           style="margin-bottom:0.8rem;"/>
+                            <p>
+                                <strong>Processed:</strong> #{institutionController.importProcessed} of #{institutionController.importTotal} rows
+                            </p>
+                            <p>
+                                <strong>Created:</strong> #{institutionController.importCreated} &#160;
+                                <strong>Skipped:</strong> #{institutionController.importSkipped}
+                            </p>
+                        </p:panel>
+                    </h:panelGroup>
+
+                    <h:panelGroup id="donePanel" layout="block">
+                        <p:panel rendered="#{!institutionController.importRunning and institutionController.importTotal gt 0}"
+                                 style="margin-top:1rem;">
+                            <f:facet name="header">Import Complete</f:facet>
+                            <p style="color:green;">
+                                <strong>Created:</strong> #{institutionController.importCreated} &#160;
+                                <strong>Skipped:</strong> #{institutionController.importSkipped} &#160;
+                                <strong>Total rows processed:</strong> #{institutionController.importProcessed}
+                            </p>
+                            <p:dataList value="#{institutionController.importWarnings}" var="w"
+                                        rendered="#{not empty institutionController.importWarnings}"
+                                        style="color:orange; margin-top:0.5rem;">
+                                <h:outputText value="#{w}"/>
+                            </p:dataList>
+                        </p:panel>
+                    </h:panelGroup>
+
+                    <p:poll id="importPoll"
+                            interval="2"
+                            autoStart="true"
+                            update="progressPanel donePanel"
+                            stop="#{!institutionController.importRunning}"/>
+                </h:form>
+
             </ui:define>
         </ui:composition>
-
     </body>
 </html>

--- a/src/main/webapp/institution/index.xhtml
+++ b/src/main/webapp/institution/index.xhtml
@@ -38,7 +38,11 @@
                                              value="Add Draining GN Areas for Health Institutions" 
                                              action="#{areaController.toImportInstitutionDrainingAreas()}"  ></p:commandButton>
 
-                            <p:commandButton value="Reload Institutions" ajax="false" 
+                            <p:commandButton value="Import Institutions from Excel" ajax="false"
+                                             style="width: 15rem; margin-top:1rem;"
+                                             action="#{institutionController.toImportInstitution()}"></p:commandButton>
+
+                            <p:commandButton value="Reload Institutions" ajax="false"
                                              style="width: 15rem; margin-top:1rem;"
                                              action="#{institutionController.resetAllInstitutions()}">
 

--- a/src/main/webapp/institution/list.xhtml
+++ b/src/main/webapp/institution/list.xhtml
@@ -15,9 +15,10 @@
                         <p:dataExporter target="datalist" type="xls" fileName="institutions"/>
                     </p:commandButton>
 
-                    <p:commandButton value="Delete Selected" ajax="false"
+                    <p:commandButton value="Delete Selected"
                                      style="margin-right:0.5rem;"
                                      action="#{institutionController.deleteSelectedItems()}"
+                                     update="datalist"
                                      onclick="return confirm('Are you sure you want to delete the selected institutions? This cannot be undone.');"/>
 
                     <p:dataTable id="datalist" value="#{institutionController.items}" var="item"
@@ -28,55 +29,58 @@
                                  rows="10"
                                  rowsPerPageTemplate="10,20,30,40,50">
 
+                        <p:ajax event="rowSelect"/>
+                        <p:ajax event="rowUnselect"/>
+
                         <p:column selectionMode="multiple" style="width:2.5rem; text-align:center;" exportable="false"/>
 
-                        <p:column sortBy="#{item.institutionType.label}" filterBy="#{item.institutionType.label}" filterMatchMode="contains">
+                        <p:column sortBy="#{item.institutionType.label}" filterBy="#{item.institutionType.label}" filterMatchMode="contains" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="Type"/>
                             </f:facet>
                             <h:outputText value="#{item.institutionType.label}"/>
                         </p:column>
 
-                        <p:column sortBy="#{item.name}" filterBy="#{item.name}" filterMatchMode="contains">
+                        <p:column sortBy="#{item.name}" filterBy="#{item.name}" filterMatchMode="contains" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="Name"/>
                             </f:facet>
                             <h:outputText value="#{item.name}"/>
                         </p:column>
 
-                        <p:column sortBy="#{item.pmci}">
+                        <p:column sortBy="#{item.pmci}" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="PMCI"/>
                             </f:facet>
                             <h:outputText value="#{item.pmci?'Yes':'No'}"/>
                         </p:column>
 
-                        <p:column sortBy="#{item.phone}" filterBy="#{item.phone}" filterMatchMode="contains">
+                        <p:column sortBy="#{item.phone}" filterBy="#{item.phone}" filterMatchMode="contains" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="Phone"/>
                             </f:facet>
                             <h:outputText value="#{item.phone}"/>
                         </p:column>
-                        <p:column sortBy="#{item.poiInstitution.name}" filterBy="#{item.poiInstitution.name}" filterMatchMode="contains">
+                        <p:column sortBy="#{item.poiInstitution.name}" filterBy="#{item.poiInstitution.name}" filterMatchMode="contains" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="POI Issued By"/>
                             </f:facet>
                             <h:outputText value="#{item.poiInstitution.name}"/>
                         </p:column>
-                        <p:column sortBy="#{item.parent.name}" filterBy="#{item.parent.name}" filterMatchMode="contains">
+                        <p:column sortBy="#{item.parent.name}" filterBy="#{item.parent.name}" filterMatchMode="contains" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="Governed By"/>
                             </f:facet>
                             <h:outputText value="#{item.parent.name}"/>
                         </p:column>
-                        <p:column sortBy="#{item.district.name}" filterBy="#{item.district.name}" filterMatchMode="contains">
+                        <p:column sortBy="#{item.district.name}" filterBy="#{item.district.name}" filterMatchMode="contains" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="District"/>
                             </f:facet>
                             <h:outputText value="#{item.district.name}"/>
                         </p:column>
 
-                        <p:column headerText="Actions" exportable="false">
+                        <p:column headerText="Actions" exportable="false" onclick="event.stopPropagation()">
                             <p:commandButton value="Edit" ajax="false" class="m-1"
                                              action="#{institutionController.toEditInstitution()}">
                                 <f:setPropertyActionListener value="#{item}" target="#{institutionController.selected}"/>

--- a/src/main/webapp/institution/list.xhtml
+++ b/src/main/webapp/institution/list.xhtml
@@ -15,22 +15,35 @@
                         <p:dataExporter target="datalist" type="xls" fileName="institutions"/>
                     </p:commandButton>
 
+                    <p:commandButton value="Select All"
+                                     style="margin-right:0.5rem;"
+                                     action="#{institutionController.selectAllInstitutions()}"
+                                     update="datalist"
+                                     process="@this"/>
+
+                    <p:commandButton value="Deselect All"
+                                     style="margin-right:0.5rem;"
+                                     action="#{institutionController.deselectAllInstitutions()}"
+                                     process="@this"
+                                     oncomplete="PF('institutionTable').unselectAllRows();"/>
+
                     <p:commandButton value="Delete Selected"
                                      style="margin-right:0.5rem;"
                                      action="#{institutionController.deleteSelectedItems()}"
                                      update="datalist"
                                      onclick="return confirm('Are you sure you want to delete the selected institutions? This cannot be undone.');"/>
 
-                    <p:dataTable id="datalist" value="#{institutionController.items}" var="item"
-                                 selectionMode="multiple"
+                    <p:dataTable id="datalist" widgetVar="institutionTable" value="#{institutionController.items}" var="item"
                                  selection="#{institutionController.selectedItems}"
+                                 styleClass="apple-checkbox-table"
                                  paginator="true"
                                  rowKey="#{item.id}"
                                  rows="10"
                                  rowsPerPageTemplate="10,20,30,40,50">
 
-                        <p:ajax event="rowSelect"/>
-                        <p:ajax event="rowUnselect"/>
+                        <p:ajax event="rowSelectCheckbox"/>
+                        <p:ajax event="rowUnselectCheckbox"/>
+                        <p:ajax event="toggleSelect"/>
 
                         <p:column selectionMode="multiple" style="width:2.5rem; text-align:center;" exportable="false"/>
 

--- a/src/main/webapp/institution/list.xhtml
+++ b/src/main/webapp/institution/list.xhtml
@@ -18,8 +18,7 @@
                     <p:commandButton value="Delete Selected" ajax="false"
                                      style="margin-right:0.5rem;"
                                      action="#{institutionController.deleteSelectedItems()}"
-                                     onclick="return confirm('Are you sure you want to delete the selected institutions? This cannot be undone.');"
-                                     disabled="#{empty institutionController.selectedItems}"/>
+                                     onclick="return confirm('Are you sure you want to delete the selected institutions? This cannot be undone.');"/>
 
                     <p:dataTable id="datalist" value="#{institutionController.items}" var="item"
                                  selectionMode="multiple"

--- a/src/main/webapp/institution/list.xhtml
+++ b/src/main/webapp/institution/list.xhtml
@@ -9,73 +9,86 @@
     <body>
         <ui:composition template="/institution/index.xhtml">
             <ui:define name="insContents">
-                <h:form id="InstitutionListForm">  
-                    
-                    <p:commandButton value="Download" ajax="false" >
-                        <p:dataExporter target="datalist" type="xls" fileName="institutions" ></p:dataExporter>
+                <h:form id="InstitutionListForm">
+
+                    <p:commandButton value="Download" ajax="false" style="margin-right:0.5rem;">
+                        <p:dataExporter target="datalist" type="xls" fileName="institutions"/>
                     </p:commandButton>
-                    
+
+                    <p:commandButton value="Delete Selected" ajax="false"
+                                     style="margin-right:0.5rem;"
+                                     action="#{institutionController.deleteSelectedItems()}"
+                                     onclick="return confirm('Are you sure you want to delete the selected institutions? This cannot be undone.');"
+                                     disabled="#{empty institutionController.selectedItems}"/>
+
                     <p:dataTable id="datalist" value="#{institutionController.items}" var="item"
-                                 selectionMode="single" selection="#{institutionController.selected}"
+                                 selectionMode="multiple"
+                                 selection="#{institutionController.selectedItems}"
                                  paginator="true"
                                  rowKey="#{item.id}"
                                  rows="10"
                                  rowsPerPageTemplate="10,20,30,40,50">
 
-                        <p:ajax event="rowSelect"   update="createButton viewButton editButton deleteButton"/>
-                        <p:ajax event="rowUnselect" update="createButton viewButton editButton deleteButton"/>
+                        <p:column selectionMode="multiple" style="width:2.5rem; text-align:center;" exportable="false"/>
 
-                        <p:column sortBy="#{item.institutionType.label}" filterBy="#{item.institutionType.label}" filterMatchMode="contains" >
+                        <p:column sortBy="#{item.institutionType.label}" filterBy="#{item.institutionType.label}" filterMatchMode="contains">
                             <f:facet name="header">
                                 <h:outputText value="Type"/>
                             </f:facet>
                             <h:outputText value="#{item.institutionType.label}"/>
                         </p:column>
 
-                        <p:column sortBy="#{item.name}" filterBy="#{item.name}" filterMatchMode="contains" >
+                        <p:column sortBy="#{item.name}" filterBy="#{item.name}" filterMatchMode="contains">
                             <f:facet name="header">
                                 <h:outputText value="Name"/>
                             </f:facet>
                             <h:outputText value="#{item.name}"/>
                         </p:column>
 
-                        <p:column sortBy="#{item.pmci}" >
+                        <p:column sortBy="#{item.pmci}">
                             <f:facet name="header">
                                 <h:outputText value="PMCI"/>
                             </f:facet>
                             <h:outputText value="#{item.pmci?'Yes':'No'}"/>
                         </p:column>
 
-                        <p:column sortBy="#{item.phone}" filterBy="#{item.phone}" filterMatchMode="contains" >
+                        <p:column sortBy="#{item.phone}" filterBy="#{item.phone}" filterMatchMode="contains">
                             <f:facet name="header">
                                 <h:outputText value="Phone"/>
                             </f:facet>
                             <h:outputText value="#{item.phone}"/>
                         </p:column>
-                        <p:column sortBy="#{item.poiInstitution.name}" filterBy="#{item.poiInstitution.name}" filterMatchMode="contains" >
+                        <p:column sortBy="#{item.poiInstitution.name}" filterBy="#{item.poiInstitution.name}" filterMatchMode="contains">
                             <f:facet name="header">
                                 <h:outputText value="POI Issued By"/>
                             </f:facet>
                             <h:outputText value="#{item.poiInstitution.name}"/>
                         </p:column>
-                        <p:column sortBy="#{item.parent.name}" filterBy="#{item.parent.name}" filterMatchMode="contains" >
+                        <p:column sortBy="#{item.parent.name}" filterBy="#{item.parent.name}" filterMatchMode="contains">
                             <f:facet name="header">
                                 <h:outputText value="Governed By"/>
                             </f:facet>
                             <h:outputText value="#{item.parent.name}"/>
                         </p:column>
-                        <p:column sortBy="#{item.district.name}" filterBy="#{item.district.name}" filterMatchMode="contains" >
+                        <p:column sortBy="#{item.district.name}" filterBy="#{item.district.name}" filterMatchMode="contains">
                             <f:facet name="header">
                                 <h:outputText value="District"/>
                             </f:facet>
                             <h:outputText value="#{item.district.name}"/>
                         </p:column>
-                        <f:facet name="footer">
-                            <p:commandButton id="createButton" icon="ui-icon-plus"   value="#{bundleClinical.Create}" actionListener="#{institutionController.prepareCreate}" update=":InstitutionCreateForm" oncomplete="PF('InstitutionCreateDialog').show()"/>
-                            <p:commandButton id="viewButton"   icon="ui-icon-search" value="#{bundleClinical.View}" update=":InstitutionViewForm" oncomplete="PF('InstitutionViewDialog').show()" disabled="#{empty institutionController.selected}"/>
-                            <p:commandButton id="editButton"   icon="ui-icon-pencil" value="#{bundleClinical.Edit}" update=":InstitutionEditForm" oncomplete="PF('InstitutionEditDialog').show()" disabled="#{empty institutionController.selected}"/>
-                            <p:commandButton id="deleteButton" icon="ui-icon-trash"  value="#{bundleClinical.Delete}" actionListener="#{institutionController.destroy}" update="datalist" disabled="#{empty institutionController.selected}"/>
-                        </f:facet>
+
+                        <p:column headerText="Actions" exportable="false">
+                            <p:commandButton value="Edit" ajax="false" class="m-1"
+                                             action="#{institutionController.toEditInstitution()}">
+                                <f:setPropertyActionListener value="#{item}" target="#{institutionController.selected}"/>
+                            </p:commandButton>
+                            <p:commandButton value="Delete" ajax="false" class="m-1"
+                                             action="#{institutionController.deleteInstitution()}"
+                                             onclick="return confirm('Are you sure you want to delete this institution?');">
+                                <f:setPropertyActionListener value="#{item}" target="#{institutionController.selected}"/>
+                            </p:commandButton>
+                        </p:column>
+
                     </p:dataTable>
                 </h:form>
 

--- a/src/main/webapp/item/List.xhtml
+++ b/src/main/webapp/item/List.xhtml
@@ -16,22 +16,33 @@
                 </p:commandButton>
                 <p:commandButton value="Reload" ajax="false" class="m-1"
                                  action="#{itemController.reloadItems()}"/>
+                <p:commandButton value="Select All" class="m-1"
+                                 action="#{itemController.selectAllDictionaryItems()}"
+                                 update="datalist"
+                                 process="@this"/>
+
+                <p:commandButton value="Deselect All" class="m-1"
+                                 action="#{itemController.deselectAllDictionaryItems()}"
+                                 process="@this"
+                                 oncomplete="PF('itemTable').unselectAllRows();"/>
+
                 <p:commandButton value="Delete Selected" class="m-1"
                                  action="#{itemController.destroySelected()}"
                                  update="datalist"
                                  onclick="return confirm('Are you sure you want to delete the selected items? This cannot be undone.');"/>
 
                 <p:panel header="#{bundleClinical.ListItemTitle}">
-                    <p:dataTable id="datalist" value="#{itemController.items}" var="item"
-                                 selectionMode="multiple"
+                    <p:dataTable id="datalist" widgetVar="itemTable" value="#{itemController.items}" var="item"
                                  selection="#{itemController.selectedItems}"
+                                 styleClass="apple-checkbox-table"
                                  paginator="true"
                                  rowKey="#{item.id}"
                                  rows="10"
                                  rowsPerPageTemplate="10,20,30,40,50">
 
-                        <p:ajax event="rowSelect"   update="editButton viewButton createButton"/>
-                        <p:ajax event="rowUnselect" update="editButton viewButton createButton"/>
+                        <p:ajax event="rowSelectCheckbox" update="editButton viewButton createButton"/>
+                        <p:ajax event="rowUnselectCheckbox" update="editButton viewButton createButton"/>
+                        <p:ajax event="toggleSelect" update="editButton viewButton createButton"/>
 
                         <p:column selectionMode="multiple" style="width:2.5rem; text-align:center;" exportable="false"/>
 

--- a/src/main/webapp/item/List.xhtml
+++ b/src/main/webapp/item/List.xhtml
@@ -16,8 +16,9 @@
                 </p:commandButton>
                 <p:commandButton value="Reload" ajax="false" class="m-1"
                                  action="#{itemController.reloadItems()}"/>
-                <p:commandButton value="Delete Selected" ajax="false" class="m-1"
+                <p:commandButton value="Delete Selected" class="m-1"
                                  action="#{itemController.destroySelected()}"
+                                 update="datalist"
                                  onclick="return confirm('Are you sure you want to delete the selected items? This cannot be undone.');"/>
 
                 <p:panel header="#{bundleClinical.ListItemTitle}">
@@ -34,49 +35,49 @@
 
                         <p:column selectionMode="multiple" style="width:2.5rem; text-align:center;" exportable="false"/>
 
-                        <p:column filterBy="#{item.id}" filterMatchMode="contains" sortBy="#{item.id}">
+                        <p:column filterBy="#{item.id}" filterMatchMode="contains" sortBy="#{item.id}" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="ID"/>
                             </f:facet>
                             <h:outputText value="#{item.id}"/>
                         </p:column>
 
-                        <p:column rendered="false" filterBy="#{item.itemType.label}" filterMatchMode="contains" sortBy="#{item.itemType.label}">
+                        <p:column rendered="false" filterBy="#{item.itemType.label}" filterMatchMode="contains" sortBy="#{item.itemType.label}" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="#{bundleClinical.ListItemTitle_itemType}"/>
                             </f:facet>
                             <h:outputText value="#{item.itemType.label}"/>
                         </p:column>
 
-                        <p:column filterBy="#{item.name}" filterMatchMode="contains" sortBy="#{item.name}">
+                        <p:column filterBy="#{item.name}" filterMatchMode="contains" sortBy="#{item.name}" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="#{bundleClinical.ListItemTitle_name}"/>
                             </f:facet>
                             <h:outputText value="#{item.name}"/>
                         </p:column>
 
-                        <p:column rendered="false" filterBy="#{item.displayName}" filterMatchMode="contains" sortBy="#{item.displayName}">
+                        <p:column rendered="false" filterBy="#{item.displayName}" filterMatchMode="contains" sortBy="#{item.displayName}" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="Display Name"/>
                             </f:facet>
                             <h:outputText value="#{item.displayName}"/>
                         </p:column>
 
-                        <p:column filterBy="#{item.code}" filterMatchMode="contains" sortBy="#{item.code}">
+                        <p:column filterBy="#{item.code}" filterMatchMode="contains" sortBy="#{item.code}" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="Code"/>
                             </f:facet>
                             <h:outputText value="#{item.code}"/>
                         </p:column>
 
-                        <p:column filterBy="#{item.dataType.label}" filterMatchMode="contains" sortBy="#{item.dataType.label}">
+                        <p:column filterBy="#{item.dataType.label}" filterMatchMode="contains" sortBy="#{item.dataType.label}" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="Data Type"/>
                             </f:facet>
                             <h:outputText value="#{item.dataType.label}"/>
                         </p:column>
 
-                        <p:column filterBy="#{item.parent.name}" filterMatchMode="contains" sortBy="#{item.parent.name}">
+                        <p:column filterBy="#{item.parent.name}" filterMatchMode="contains" sortBy="#{item.parent.name}" onclick="event.stopPropagation()">
                             <f:facet name="header">
                                 <h:outputText value="Parent"/>
                             </f:facet>

--- a/src/main/webapp/item/List.xhtml
+++ b/src/main/webapp/item/List.xhtml
@@ -8,40 +8,39 @@
 
     <ui:composition template="/systemAdmin/manage_metadata_index.xhtml">
 
-
         <ui:define name="metadata">
             <h:form id="ItemListForm">
-                
-                <p:commandButton value="Download" 
-                                 class="m-1"
-                                 ajax="false" >
-                    <p:dataExporter target="datalist" type="xls" fileName="dictionary" ></p:dataExporter>
+
+                <p:commandButton value="Download" class="m-1" ajax="false">
+                    <p:dataExporter target="datalist" type="xls" fileName="dictionary"/>
                 </p:commandButton>
-                <p:commandButton value="Reload"
-                                 ajax="false" 
-                                 class="m-1"
-                                 action="#{itemController.reloadItems()}" >
-                </p:commandButton>
-                
+                <p:commandButton value="Reload" ajax="false" class="m-1"
+                                 action="#{itemController.reloadItems()}"/>
+                <p:commandButton value="Delete Selected" ajax="false" class="m-1"
+                                 action="#{itemController.destroySelected()}"
+                                 onclick="return confirm('Are you sure you want to delete the selected items? This cannot be undone.');"/>
+
                 <p:panel header="#{bundleClinical.ListItemTitle}">
                     <p:dataTable id="datalist" value="#{itemController.items}" var="item"
-                                 selectionMode="single" selection="#{itemController.selected}"
+                                 selectionMode="multiple"
+                                 selection="#{itemController.selectedItems}"
                                  paginator="true"
                                  rowKey="#{item.id}"
                                  rows="10"
-                                 rowsPerPageTemplate="10,20,30,40,50"
-                                 >
+                                 rowsPerPageTemplate="10,20,30,40,50">
 
-                        <p:ajax event="rowSelect"   update="createButton viewButton editButton deleteButton"/>
-                        <p:ajax event="rowUnselect" update="createButton viewButton editButton deleteButton"/>
+                        <p:ajax event="rowSelect"   update="editButton viewButton createButton"/>
+                        <p:ajax event="rowUnselect" update="editButton viewButton createButton"/>
 
-                        <p:column rendered="true" filterBy="#{item.id}" filterMatchMode="contains" sortBy="#{item.id}">
+                        <p:column selectionMode="multiple" style="width:2.5rem; text-align:center;" exportable="false"/>
+
+                        <p:column filterBy="#{item.id}" filterMatchMode="contains" sortBy="#{item.id}">
                             <f:facet name="header">
                                 <h:outputText value="ID"/>
                             </f:facet>
                             <h:outputText value="#{item.id}"/>
                         </p:column>
-                        
+
                         <p:column rendered="false" filterBy="#{item.itemType.label}" filterMatchMode="contains" sortBy="#{item.itemType.label}">
                             <f:facet name="header">
                                 <h:outputText value="#{bundleClinical.ListItemTitle_itemType}"/>
@@ -49,46 +48,54 @@
                             <h:outputText value="#{item.itemType.label}"/>
                         </p:column>
 
-                        <p:column  filterBy="#{item.name}" filterMatchMode="contains" sortBy="#{item.name}">
+                        <p:column filterBy="#{item.name}" filterMatchMode="contains" sortBy="#{item.name}">
                             <f:facet name="header">
                                 <h:outputText value="#{bundleClinical.ListItemTitle_name}"/>
                             </f:facet>
                             <h:outputText value="#{item.name}"/>
                         </p:column>
 
-                        <p:column rendered="false"  filterBy="#{item.displayName}" filterMatchMode="contains" sortBy="#{item.displayName}">
+                        <p:column rendered="false" filterBy="#{item.displayName}" filterMatchMode="contains" sortBy="#{item.displayName}">
                             <f:facet name="header">
                                 <h:outputText value="Display Name"/>
                             </f:facet>
                             <h:outputText value="#{item.displayName}"/>
                         </p:column>
 
-
-                        <p:column  filterBy="#{item.code}" filterMatchMode="contains" sortBy="#{item.code}">
+                        <p:column filterBy="#{item.code}" filterMatchMode="contains" sortBy="#{item.code}">
                             <f:facet name="header">
                                 <h:outputText value="Code"/>
                             </f:facet>
                             <h:outputText value="#{item.code}"/>
                         </p:column>
 
-                        <p:column  filterBy="#{item.dataType.label}" filterMatchMode="contains" sortBy="#{item.dataType.label}">
+                        <p:column filterBy="#{item.dataType.label}" filterMatchMode="contains" sortBy="#{item.dataType.label}">
                             <f:facet name="header">
                                 <h:outputText value="Data Type"/>
                             </f:facet>
                             <h:outputText value="#{item.dataType.label}"/>
                         </p:column>
 
-                        <p:column  filterBy="#{item.parent.name}" filterMatchMode="contains" sortBy="#{item.parent.name}">
+                        <p:column filterBy="#{item.parent.name}" filterMatchMode="contains" sortBy="#{item.parent.name}">
                             <f:facet name="header">
                                 <h:outputText value="Parent"/>
                             </f:facet>
                             <h:outputText value="#{item.parent.name}"/>
                         </p:column>
+
                         <f:facet name="footer">
-                            <p:commandButton id="createButton" class="m-1" icon="ui-icon-plus"   value="#{bundleClinical.Create}" actionListener="#{itemController.prepareCreate}" update=":ItemCreateForm" oncomplete="PF('ItemCreateDialog').show()"/>
-                            <p:commandButton id="viewButton"  class="m-1" icon="ui-icon-search" value="#{bundleClinical.View}" update=":ItemViewForm" oncomplete="PF('ItemViewDialog').show()" disabled="#{empty itemController.selected}"/>
-                            <p:commandButton id="editButton"  class="m-1" icon="ui-icon-pencil" value="#{bundleClinical.Edit}" update=":ItemEditForm" oncomplete="PF('ItemEditDialog').show()" disabled="#{empty itemController.selected}"/>
-                            <p:commandButton id="deleteButton" class="m-1" icon="ui-icon-trash"  value="#{bundleClinical.Delete}" actionListener="#{itemController.destroy}" update="datalist" disabled="#{empty itemController.selected}"/>
+                            <p:commandButton id="createButton" class="m-1" icon="ui-icon-plus"
+                                             value="#{bundleClinical.Create}"
+                                             actionListener="#{itemController.prepareCreate}"
+                                             update=":ItemCreateForm" oncomplete="PF('ItemCreateDialog').show()"/>
+                            <p:commandButton id="viewButton" class="m-1" icon="ui-icon-search"
+                                             value="#{bundleClinical.View}"
+                                             update=":ItemViewForm" oncomplete="PF('ItemViewDialog').show()"
+                                             disabled="#{empty itemController.selected}"/>
+                            <p:commandButton id="editButton" class="m-1" icon="ui-icon-pencil"
+                                             value="#{bundleClinical.Edit}"
+                                             update=":ItemEditForm" oncomplete="PF('ItemEditDialog').show()"
+                                             disabled="#{empty itemController.selected}"/>
                         </f:facet>
                     </p:dataTable>
                 </p:panel>
@@ -97,14 +104,7 @@
             <ui:include src="Create.xhtml"/>
             <ui:include src="Edit.xhtml"/>
             <ui:include src="View.xhtml"/>
-            
-            
-            <br/>
-            <br/>
-            <br/>
-            <br/>
-            
-            
+
         </ui:define>
     </ui:composition>
 

--- a/src/main/webapp/resources/css/jsfcrud.css
+++ b/src/main/webapp/resources/css/jsfcrud.css
@@ -80,3 +80,50 @@ tr.jsfcrud_even_row {
     left: 50%;
     top: 50%;
 }
+
+/* Apple Notes / Reminders style checkboxes for selection columns */
+.apple-checkbox-table .ui-chkbox .ui-chkbox-box {
+    width: 20px !important;
+    height: 20px !important;
+    border: 2px solid #c7c7cc !important;
+    background: #ffffff !important;
+    border-radius: 50% !important;
+    position: relative !important;
+    box-sizing: border-box !important;
+    transition: background-color 0.15s ease, border-color 0.15s ease !important;
+    box-shadow: none !important;
+}
+
+.apple-checkbox-table .ui-chkbox .ui-chkbox-box.ui-state-hover {
+    border-color: #007aff !important;
+    background: #ffffff !important;
+}
+
+.apple-checkbox-table .ui-chkbox .ui-chkbox-box.ui-state-active,
+.apple-checkbox-table .ui-chkbox .ui-chkbox-box.ui-state-active.ui-state-hover {
+    border-color: #007aff !important;
+    background: #007aff !important;
+}
+
+/* Hide PrimeFaces icon font; tick drawn via CSS pseudo-element below */
+.apple-checkbox-table .ui-chkbox .ui-chkbox-box .ui-chkbox-icon {
+    display: none !important;
+}
+
+.apple-checkbox-table .ui-chkbox .ui-chkbox-box.ui-state-active::after {
+    content: "";
+    position: absolute;
+    left: 5px;
+    top: 1px;
+    width: 5px;
+    height: 10px;
+    border: solid #ffffff;
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+    box-sizing: border-box;
+}
+
+/* Suppress per-row hover specifically inside apple-checkbox tables */
+.apple-checkbox-table.ui-datatable .ui-datatable-data > tr:hover > td {
+    background-color: transparent !important;
+}

--- a/src/main/webapp/resources/css/tem1.css
+++ b/src/main/webapp/resources/css/tem1.css
@@ -956,16 +956,10 @@ body {
     font-weight: bold;
 }
 
-/* ── DataTable row hover & selection ── */
-.ui-datatable .ui-datatable-data > tr:hover > td {
-    background-color: #e8f4fd !important;
-}
+/* ── DataTable selection highlight ── */
 .ui-datatable .ui-datatable-data > tr.ui-state-highlight > td {
     background-color: #cce5ff !important;
     color: #004085 !important;
-}
-.dark-mode .ui-datatable .ui-datatable-data > tr:hover > td {
-    background-color: #3b4a5f !important;
 }
 .dark-mode .ui-datatable .ui-datatable-data > tr.ui-state-highlight > td {
     background-color: #2d4f6f !important;

--- a/src/main/webapp/resources/css/tem1.css
+++ b/src/main/webapp/resources/css/tem1.css
@@ -955,3 +955,19 @@ body {
     color: #ea5455;
     font-weight: bold;
 }
+
+/* ── DataTable row hover & selection ── */
+.ui-datatable .ui-datatable-data > tr:hover > td {
+    background-color: #e8f4fd !important;
+}
+.ui-datatable .ui-datatable-data > tr.ui-state-highlight > td {
+    background-color: #cce5ff !important;
+    color: #004085 !important;
+}
+.dark-mode .ui-datatable .ui-datatable-data > tr:hover > td {
+    background-color: #3b4a5f !important;
+}
+.dark-mode .ui-datatable .ui-datatable-data > tr.ui-state-highlight > td {
+    background-color: #2d4f6f !important;
+    color: #d0d2d6 !important;
+}

--- a/src/main/webapp/resources/ezcomp/institution_admin_menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/institution_admin_menu.xhtml
@@ -43,25 +43,39 @@
                 <!--//Disabled the Menu-->
                 <p:submenu label="Institution Administration"  
                            rendered="#{webUserController.hasPrivilege('Institution_Administration')}"  >
-                    <p:menuitem value="Manage Users" 
+                    <p:menuitem value="Manage Users" icon="pi pi-users"
                                 action="/insAdmin/user_index" ajax="false"
                                 rendered="#{webUserController.hasPrivilege('Institution_Administration')}" />
-                    <p:menuitem value="Manage Institutions" action="/insAdmin/institution_index" rendered="#{webUserController.hasPrivilege('Institution_Administration')}" />
-                    <p:menuitem value="Manage Areas" action="/insAdmin/area_index" ajax="false" rendered="#{webUserController.hasPrivilege('Institution_Administration')}" />
-                    <p:menuitem value="Manage Metadata" action="/insAdmin/data_index"   ajax="false"  rendered="#{webUserController.hasPrivilege('Institution_Administration')}"/>
+                    <p:menuitem value="Manage Institutions" icon="pi pi-building"
+                                action="/insAdmin/institution_index" ajax="false"
+                                rendered="#{webUserController.hasPrivilege('Institution_Administration')}" />
+                    <p:menuitem value="Manage Areas" icon="pi pi-map"
+                                action="/insAdmin/area_index" ajax="false"
+                                rendered="#{webUserController.hasPrivilege('Institution_Administration')}" />
+                    <p:menuitem value="Manage Metadata" icon="pi pi-database"
+                                action="/insAdmin/data_index" ajax="false"
+                                rendered="#{webUserController.hasPrivilege('Institution_Administration')}"/>
                 </p:submenu>
                 <!--//Disabled the Menu-->
-                <p:submenu label="System Administration"  
+                <p:submenu label="System Administration"
                            disabled="false"
-                           rendered="#{webUserController.hasPrivilege('System_Administration')}"  >
-                    <p:menuitem value="Manage Users" action="#{webUserController.toManageUserIndexForSystemAdmin()}"  ajax="false" />
-                    <p:menuitem value="Manage Institutions" action="/institution/index"     ajax="false" />
-                    <p:menuitem value="Manage Areas" action="/area/index" ajax="false"    />
-                    <p:menuitem value="Manage Metadata" action="/systemAdmin/manage_metadata_index"    ajax="false" />
-                    <p:menuitem value="Manage Data" action="/systemAdmin/manage_data_index"    ajax="false" />
-                    <p:menuitem value="Manage Interfaces" action="/systemAdmin/integration_index"    ajax="false" />
-                    <p:menuitem value="Manage Analysis"  action="/queryComponent/index"     ajax="false" />
-                    <p:menuitem value="Manage Preferances"  action="#{preferenceController.toManagePreferences()}"     ajax="false" />
+                           rendered="#{webUserController.hasPrivilege('System_Administration')}">
+                    <p:menuitem value="Manage Users" icon="pi pi-users"
+                                action="#{webUserController.toManageUserIndexForSystemAdmin()}" ajax="false" />
+                    <p:menuitem value="Manage Institutions" icon="pi pi-building"
+                                action="/institution/index" ajax="false" />
+                    <p:menuitem value="Manage Areas" icon="pi pi-map"
+                                action="/area/index" ajax="false" />
+                    <p:menuitem value="Manage Metadata" icon="pi pi-database"
+                                action="/systemAdmin/manage_metadata_index" ajax="false" />
+                    <p:menuitem value="Manage Data" icon="pi pi-table"
+                                action="/systemAdmin/manage_data_index" ajax="false" />
+                    <p:menuitem value="Manage Interfaces" icon="pi pi-sitemap"
+                                action="/systemAdmin/integration_index" ajax="false" />
+                    <p:menuitem value="Manage Analysis" icon="pi pi-chart-bar"
+                                action="/queryComponent/index" ajax="false" />
+                    <p:menuitem value="Manage Preferences" icon="pi pi-cog"
+                                action="#{preferenceController.toManagePreferences()}" ajax="false" />
                 </p:submenu>
                 <p:submenu label="Settings" >
                     <p:menuitem value="Change My Password" action="#{webUserController.toChangeMyPassword()}" ajax="false" />

--- a/src/main/webapp/resources/ezcomp/institution_user_menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/institution_user_menu.xhtml
@@ -43,25 +43,39 @@
                 <!--//Disabled the Menu-->
                 <p:submenu label="Institution Administration"  
                            rendered="#{webUserController.hasPrivilege('Institution_Administration')}"  >
-                    <p:menuitem value="Manage Users" 
+                    <p:menuitem value="Manage Users" icon="pi pi-users"
                                 action="/insAdmin/user_index" ajax="false"
                                 rendered="#{webUserController.hasPrivilege('Institution_Administration')}" />
-                    <p:menuitem value="Manage Institutions" action="/insAdmin/institution_index" rendered="#{webUserController.hasPrivilege('Institution_Administration')}" />
-                    <p:menuitem value="Manage Areas" action="/insAdmin/area_index" ajax="false" rendered="#{webUserController.hasPrivilege('Institution_Administration')}" />
-                    <p:menuitem value="Manage Metadata" action="/insAdmin/data_index"   ajax="false"  rendered="#{webUserController.hasPrivilege('Institution_Administration')}"/>
+                    <p:menuitem value="Manage Institutions" icon="pi pi-building"
+                                action="/insAdmin/institution_index" ajax="false"
+                                rendered="#{webUserController.hasPrivilege('Institution_Administration')}" />
+                    <p:menuitem value="Manage Areas" icon="pi pi-map"
+                                action="/insAdmin/area_index" ajax="false"
+                                rendered="#{webUserController.hasPrivilege('Institution_Administration')}" />
+                    <p:menuitem value="Manage Metadata" icon="pi pi-database"
+                                action="/insAdmin/data_index" ajax="false"
+                                rendered="#{webUserController.hasPrivilege('Institution_Administration')}"/>
                 </p:submenu>
                 <!--//Disabled the Menu-->
-                <p:submenu label="System Administration"  
+                <p:submenu label="System Administration"
                            disabled="false"
-                           rendered="#{webUserController.hasPrivilege('System_Administration')}"  >
-                    <p:menuitem value="Manage Users" action="#{webUserController.toManageUserIndexForSystemAdmin()}"  ajax="false" />
-                    <p:menuitem value="Manage Institutions" action="/institution/index"     ajax="false" />
-                    <p:menuitem value="Manage Areas" action="/area/index" ajax="false"    />
-                    <p:menuitem value="Manage Metadata" action="/systemAdmin/manage_metadata_index"    ajax="false" />
-                    <p:menuitem value="Manage Data" action="/systemAdmin/manage_data_index"    ajax="false" />
-                    <p:menuitem value="Manage Interfaces" action="/systemAdmin/integration_index"    ajax="false" />
-                    <p:menuitem value="Manage Analysis"  action="/queryComponent/index"     ajax="false" />
-                    <p:menuitem value="Manage Preferances"  action="#{preferenceController.toManagePreferences()}"     ajax="false" />
+                           rendered="#{webUserController.hasPrivilege('System_Administration')}">
+                    <p:menuitem value="Manage Users" icon="pi pi-users"
+                                action="#{webUserController.toManageUserIndexForSystemAdmin()}" ajax="false" />
+                    <p:menuitem value="Manage Institutions" icon="pi pi-building"
+                                action="/institution/index" ajax="false" />
+                    <p:menuitem value="Manage Areas" icon="pi pi-map"
+                                action="/area/index" ajax="false" />
+                    <p:menuitem value="Manage Metadata" icon="pi pi-database"
+                                action="/systemAdmin/manage_metadata_index" ajax="false" />
+                    <p:menuitem value="Manage Data" icon="pi pi-table"
+                                action="/systemAdmin/manage_data_index" ajax="false" />
+                    <p:menuitem value="Manage Interfaces" icon="pi pi-sitemap"
+                                action="/systemAdmin/integration_index" ajax="false" />
+                    <p:menuitem value="Manage Analysis" icon="pi pi-chart-bar"
+                                action="/queryComponent/index" ajax="false" />
+                    <p:menuitem value="Manage Preferences" icon="pi pi-cog"
+                                action="#{preferenceController.toManagePreferences()}" ajax="false" />
                 </p:submenu>
                 <p:submenu label="Settings" >
                     <p:menuitem value="Change My Password" action="#{webUserController.toChangeMyPassword()}" ajax="false" />

--- a/src/main/webapp/resources/ezcomp/me_menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/me_menu.xhtml
@@ -43,25 +43,39 @@
                 <!--//Disabled the Menu-->
                 <p:submenu label="Institution Administration"  
                            rendered="#{webUserController.hasPrivilege('Institution_Administration')}"  >
-                    <p:menuitem value="Manage Users" 
+                    <p:menuitem value="Manage Users" icon="pi pi-users"
                                 action="/insAdmin/user_index" ajax="false"
                                 rendered="#{webUserController.hasPrivilege('Institution_Administration')}" />
-                    <p:menuitem value="Manage Institutions" action="/insAdmin/institution_index" rendered="#{webUserController.hasPrivilege('Institution_Administration')}" />
-                    <p:menuitem value="Manage Areas" action="/insAdmin/area_index" ajax="false" rendered="#{webUserController.hasPrivilege('Institution_Administration')}" />
-                    <p:menuitem value="Manage Metadata" action="/insAdmin/data_index"   ajax="false"  rendered="#{webUserController.hasPrivilege('Institution_Administration')}"/>
+                    <p:menuitem value="Manage Institutions" icon="pi pi-building"
+                                action="/insAdmin/institution_index" ajax="false"
+                                rendered="#{webUserController.hasPrivilege('Institution_Administration')}" />
+                    <p:menuitem value="Manage Areas" icon="pi pi-map"
+                                action="/insAdmin/area_index" ajax="false"
+                                rendered="#{webUserController.hasPrivilege('Institution_Administration')}" />
+                    <p:menuitem value="Manage Metadata" icon="pi pi-database"
+                                action="/insAdmin/data_index" ajax="false"
+                                rendered="#{webUserController.hasPrivilege('Institution_Administration')}"/>
                 </p:submenu>
                 <!--//Disabled the Menu-->
-                <p:submenu label="System Administration"  
+                <p:submenu label="System Administration"
                            disabled="false"
-                           rendered="#{webUserController.hasPrivilege('System_Administration')}"  >
-                    <p:menuitem value="Manage Users" action="#{webUserController.toManageUserIndexForSystemAdmin()}"  ajax="false" />
-                    <p:menuitem value="Manage Institutions" action="/institution/index"     ajax="false" />
-                    <p:menuitem value="Manage Areas" action="/area/index" ajax="false"    />
-                    <p:menuitem value="Manage Metadata" action="/systemAdmin/manage_metadata_index"    ajax="false" />
-                    <p:menuitem value="Manage Data" action="/systemAdmin/manage_data_index"    ajax="false" />
-                    <p:menuitem value="Manage Interfaces" action="/systemAdmin/integration_index"    ajax="false" />
-                    <p:menuitem value="Manage Analysis"  action="/queryComponent/index"     ajax="false" />
-                    <p:menuitem value="Manage Preferances"  action="#{preferenceController.toManagePreferences()}"     ajax="false" />
+                           rendered="#{webUserController.hasPrivilege('System_Administration')}">
+                    <p:menuitem value="Manage Users" icon="pi pi-users"
+                                action="#{webUserController.toManageUserIndexForSystemAdmin()}" ajax="false" />
+                    <p:menuitem value="Manage Institutions" icon="pi pi-building"
+                                action="/institution/index" ajax="false" />
+                    <p:menuitem value="Manage Areas" icon="pi pi-map"
+                                action="/area/index" ajax="false" />
+                    <p:menuitem value="Manage Metadata" icon="pi pi-database"
+                                action="/systemAdmin/manage_metadata_index" ajax="false" />
+                    <p:menuitem value="Manage Data" icon="pi pi-table"
+                                action="/systemAdmin/manage_data_index" ajax="false" />
+                    <p:menuitem value="Manage Interfaces" icon="pi pi-sitemap"
+                                action="/systemAdmin/integration_index" ajax="false" />
+                    <p:menuitem value="Manage Analysis" icon="pi pi-chart-bar"
+                                action="/queryComponent/index" ajax="false" />
+                    <p:menuitem value="Manage Preferences" icon="pi pi-cog"
+                                action="#{preferenceController.toManagePreferences()}" ajax="false" />
                 </p:submenu>
                 <p:submenu label="Settings" >
                     <p:menuitem value="Change My Password" action="#{webUserController.toChangeMyPassword()}" ajax="false" />


### PR DESCRIPTION
## Summary
- Replaces default PrimeFaces checkbox styling on Area, Institution, and Dictionary lists with an Apple Notes / Reminders-style round checkbox: white background → blue fill on active, white tick drawn via a CSS pseudo-element (no dependency on PrimeFaces icon fonts).
- Switches the three lists to checkbox-only selection (clicking the row body no longer toggles selection — only the checkbox does).
- Adds Select All / Deselect All buttons to all three lists. Deselect All uses a client-side `PF(widget).unselectAllRows()` call in `oncomplete` so the tick state clears immediately.
- Removes the global per-row hover highlight introduced in 6c26a039 (kept the selection highlight).

## Files
- `src/main/webapp/resources/css/jsfcrud.css` — new `.apple-checkbox-table` styles
- `src/main/webapp/resources/css/tem1.css` — drop `:hover` rules, keep `.ui-state-highlight`
- `src/main/webapp/area/list.xhtml`, `institution/list.xhtml`, `item/List.xhtml` — styleClass, widgetVar, Select/Deselect buttons, checkbox-only selection
- `AreaController.java`, `InstitutionController.java`, `ItemController.java` — `selectAll*` / `deselectAll*` methods

## Test plan
- [ ] Area List → click row body: nothing selected
- [ ] Area List → click checkbox: blue circle with white ✓ appears
- [ ] Area List → Select All: every row ticked
- [ ] Area List → Deselect All: every tick cleared instantly
- [ ] Repeat the four checks on Institution List and Dictionary (Item) List
- [ ] Delete Selected still works after Select All / partial selection
- [ ] No regression on row hover styling elsewhere in app

🤖 Generated with [Claude Code](https://claude.com/claude-code)