### PR TITLE
Merge update flow into install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 # =============================================================================
-#  cHIMS Unified Installation Script
+#  cHIMS Unified Installation / Update Script
 #  Supports: Ubuntu 20.04+ LTS
+#
+#  First run on a fresh server  → installs OS packages, MySQL, Payara, JDBC
+#                                  pool, builds the WAR and deploys it.
+#  Subsequent runs (existing
+#  Payara + cHIMS detected)     → automatically switches to UPDATE MODE:
+#                                  rebuilds the WAR and redeploys it onto the
+#                                  running domain. No prompts, no setup.
 # =============================================================================
 
 set -euo pipefail
@@ -12,36 +19,46 @@ info()    { echo -e "${CYAN}[INFO]${NC}  $*"; }
 success() { echo -e "${GREEN}[OK]${NC}    $*"; }
 warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
 error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; exit 1; }
+section() { echo -e "\n${BOLD}--- $* ---${NC}"; }
 
 # Config
-NEW_VERSION="0.2"
+NEW_VERSION="${NEW_VERSION:-0.2}"
+APP_NAME="chims-${NEW_VERSION}"
+WAR_FILE="target/chims-${NEW_VERSION}.war"
 PAYARA_VERSION="5.2022.5"
-PAYARA_HOME="$HOME/payara5"
+PAYARA_HOME="${PAYARA_HOME:-$HOME/payara5}"
 ASADMIN="${PAYARA_HOME}/bin/asadmin"
 DB_NAME="chims_v2"
 JNDI_NAME="jdbc/chims_v2"
 POOL_NAME="chims_v2"
 
-# Banner
+# Sanity checks
+if [[ "$EUID" -eq 0 ]]; then error "Run as a normal user (with sudo access), not root."; fi
+[[ -f "pom.xml" ]] || error "pom.xml not found. Run this script from the project root."
+
 echo -e "${BOLD}cHIMS v${NEW_VERSION} Installer${NC}"
 
-# Check sudo
-if [[ "$EUID" -eq 0 ]]; then error "Run as a normal user (with sudo access), not root."; fi
+# Detect existing install → update mode
+UPDATE_MODE=false
+if [[ -x "${ASADMIN}" ]] && "${ASADMIN}" list-jdbc-connection-pools 2>/dev/null | grep -q "^${POOL_NAME}$"; then
+    UPDATE_MODE=true
+    info "Existing cHIMS installation detected — running in UPDATE MODE (rebuild + redeploy only)."
+fi
 
-# 1. System Packages
-section() { echo -e "\n${BOLD}--- $* ---${NC}"; }
-section "1. Installing System Packages"
-sudo apt-get update -qq
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
-  openjdk-11-jdk maven unzip git mysql-server wget curl gh
+if [[ "${UPDATE_MODE}" == "false" ]]; then
+    # 1. System Packages
+    section "1. Installing System Packages"
+    sudo apt-get update -qq
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+      openjdk-11-jdk maven unzip git mysql-server wget curl gh
 
-# 2. MySQL Setup
-section "2. Configuring MySQL"
-sudo systemctl enable --now mysql
-read -rsp "Enter MySQL root password: " MYSQL_ROOT_PASS; echo
-read -rsp "Enter chimsuser password: " MYSQL_CHIMS_PASS; echo
+    # 2. MySQL Setup
+    section "2. Configuring MySQL"
+    sudo systemctl enable --now mysql
+    read -rsp "Enter MySQL root password: " MYSQL_ROOT_PASS; echo
+    read -rsp "Enter chimsuser password: " MYSQL_CHIMS_PASS; echo
 
-sudo mysql -u root <<MYSQL_SETUP
+    sudo mysql -u root <<MYSQL_SETUP
 ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '${MYSQL_ROOT_PASS}';
 CREATE USER IF NOT EXISTS 'chimsuser'@'localhost' IDENTIFIED WITH mysql_native_password BY '${MYSQL_CHIMS_PASS}';
 CREATE DATABASE IF NOT EXISTS \`${DB_NAME}\`;
@@ -49,38 +66,52 @@ GRANT ALL PRIVILEGES ON \`${DB_NAME}\`.* TO 'chimsuser'@'localhost';
 FLUSH PRIVILEGES;
 MYSQL_SETUP
 
-# 3. Payara Setup
-section "3. Configuring Payara"
-if [[ ! -d "${PAYARA_HOME}" ]]; then
-    info "Downloading and extracting Payara..."
-    wget -q "https://repo1.maven.org/maven2/fish/payara/distributions/payara/${PAYARA_VERSION}/payara-${PAYARA_VERSION}.zip" -O /tmp/payara.zip
-    unzip -q /tmp/payara.zip -d "$HOME"
-    rm /tmp/payara.zip
+    # 3. Payara Setup
+    section "3. Configuring Payara"
+    if [[ ! -d "${PAYARA_HOME}" ]]; then
+        info "Downloading and extracting Payara..."
+        wget -q "https://repo1.maven.org/maven2/fish/payara/distributions/payara/${PAYARA_VERSION}/payara-${PAYARA_VERSION}.zip" -O /tmp/payara.zip
+        unzip -q /tmp/payara.zip -d "$HOME"
+        rm /tmp/payara.zip
+    fi
+
+    # MySQL Connector
+    if [[ ! -f "${PAYARA_HOME}/glassfish/lib/mysql-connector-j-8.0.33.jar" ]]; then
+        wget -q "https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.33/mysql-connector-j-8.0.33.jar" -P "${PAYARA_HOME}/glassfish/lib/"
+    fi
+
+    "${ASADMIN}" start-domain || true
+    "${ASADMIN}" add-library "${PAYARA_HOME}/glassfish/lib/mysql-connector-j-8.0.33.jar" || true
+
+    # JDBC Pool & Resource
+    "${ASADMIN}" create-jdbc-connection-pool \
+      --datasourceclassname com.mysql.cj.jdbc.MysqlDataSource \
+      --restype javax.sql.DataSource \
+      --property "ServerName=localhost:PortNumber=3306:DatabaseName=${DB_NAME}:User=chimsuser:Password=${MYSQL_CHIMS_PASS}:UseSSL=false:allowPublicKeyRetrieval=true:URL=jdbc\:mysql\://localhost\:3306/${DB_NAME}" \
+      "${POOL_NAME}" || true
+
+    "${ASADMIN}" create-jdbc-resource --connectionpoolid "${POOL_NAME}" "${JNDI_NAME}" || true
+else
+    # Update mode: just make sure domain is up before we redeploy
+    if ! "${ASADMIN}" list-domains 2>/dev/null | grep -q "domain1 running"; then
+        info "Starting domain1..."
+        "${ASADMIN}" start-domain
+    fi
 fi
 
-# MySQL Connector
-if [[ ! -f "${PAYARA_HOME}/glassfish/lib/mysql-connector-j-8.0.33.jar" ]]; then
-    wget -q "https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.33/mysql-connector-j-8.0.33.jar" -P "${PAYARA_HOME}/glassfish/lib/"
-fi
-
-"${ASADMIN}" start-domain || true
-"${ASADMIN}" add-library "${PAYARA_HOME}/glassfish/lib/mysql-connector-j-8.0.33.jar" || true
-
-# JDBC Pool & Resource
-"${ASADMIN}" create-jdbc-connection-pool \
-  --datasourceclassname com.mysql.cj.jdbc.MysqlDataSource \
-  --restype javax.sql.DataSource \
-  --property "ServerName=localhost:PortNumber=3306:DatabaseName=${DB_NAME}:User=chimsuser:Password=${MYSQL_CHIMS_PASS}:UseSSL=false:allowPublicKeyRetrieval=true:URL=jdbc\:mysql\://localhost\:3306/${DB_NAME}" \
-  "${POOL_NAME}" || true
-
-"${ASADMIN}" create-jdbc-resource --connectionpoolid "${POOL_NAME}" "${JNDI_NAME}" || true
-
-# 4. Build and Deploy
+# 4. Build and Deploy / Redeploy (always runs)
 section "4. Building and Deploying"
-mvn package -DskipTests
-WAR_FILE="target/chims-${NEW_VERSION}.war"
-"${ASADMIN}" deploy --force=true "${WAR_FILE}"
+mvn clean package -DskipTests
+[[ -f "${WAR_FILE}" ]] || error "Build failed: ${WAR_FILE} not found."
 
-success "Installation complete!"
-SERVER_IP=$(hostname -I | awk '{print $1}')
-info "Access at: http://${SERVER_IP}:8080/chims-${NEW_VERSION}"
+if "${ASADMIN}" list-applications 2>/dev/null | grep -q "^${APP_NAME} "; then
+    info "${APP_NAME} already deployed — redeploying."
+    "${ASADMIN}" redeploy --name="${APP_NAME}" "${WAR_FILE}"
+else
+    info "First-time deploy of ${APP_NAME}."
+    "${ASADMIN}" deploy --force=true "${WAR_FILE}"
+fi
+
+success "Done."
+SERVER_IP=$(hostname -I 2>/dev/null | awk '{print $1}')
+info "Access at: http://${SERVER_IP:-localhost}:8080/${APP_NAME}"


### PR DESCRIPTION
## Summary
Replaces the original `update.sh` proposal with a single, idempotent `install.sh`.

The script auto-detects whether cHIMS is already installed (Payara present and the `chims_v2` JDBC pool already created) and switches into UPDATE MODE for that run — skipping apt, MySQL prompts, Payara download, JDBC pool/resource creation, and just rebuilding the WAR and redeploying it.

Fresh runs still go through the full first-time setup.

## Changes
- Detect existing install at the top of the script; set `UPDATE_MODE=true` if Payara + JDBC pool both exist.
- In update mode, ensure `domain1` is running, then jump straight to the build/redeploy step.
- Deploy step uses `redeploy --name=chims-${VERSION}` when the app is already deployed; falls back to `deploy --force=true` on first install. Avoids the context-root mismatch that surfaced when re-running `deploy --force` on an already-deployed app.
- `NEW_VERSION` and `PAYARA_HOME` are overridable via environment variables.
- Refuses to run outside the project root (checks for `pom.xml`).
- The earlier `update.sh` from the previous version of this PR is dropped — `install.sh` handles both flows now.

So one command — `./install.sh` — covers both first install and every subsequent rebuild/redeploy.

## Test plan
- [ ] Fresh server: `./install.sh` runs all four sections (packages, MySQL, Payara, deploy)
- [ ] Existing install (Payara + JDBC pool present): `./install.sh` prints "running in UPDATE MODE", skips sections 1-3, rebuilds WAR, runs `asadmin redeploy`
- [ ] Existing install with `domain1` stopped: script starts the domain before redeploying
- [ ] Running outside the project root exits with a clear error
- [ ] Running as root exits with a clear error
- [ ] After redeploy, app reachable at `http://<host>:8080/chims-0.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)