### PR TITLE
Add async institution Excel import (replaces #356)

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/InstitutionController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/InstitutionController.java
@@ -1,9 +1,11 @@
 package lk.gov.health.phsp.bean;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import lk.gov.health.phsp.entity.Institution;
 import lk.gov.health.phsp.bean.util.JsfUtil;
 import lk.gov.health.phsp.bean.util.JsfUtil.PersistAction;
@@ -48,6 +50,9 @@ public class InstitutionController implements Serializable {
     @EJB
     private AreaFacade areaFacade;
 
+    @EJB
+    private InstitutionImportService institutionImportService;
+
     @Inject
     private WebUserController webUserController;
 
@@ -79,6 +84,11 @@ public class InstitutionController implements Serializable {
     private String startMessage;
 
     private UploadedFile file;
+
+    private volatile boolean importRunning = false;
+    private int[] importProgress = new int[4];
+    private final boolean[] importRunningFlag = {false};
+    private List<String> importWarnings = Collections.synchronizedList(new ArrayList<>());
 
     public Institution getInstitutionById(Long id) {
         return getFacade().find(id);
@@ -515,96 +525,73 @@ public class InstitutionController implements Serializable {
         successMessage = "";
         failureMessage = "";
 
-        String newLine = "<br/>";
-
-        try {
-
-            File inputWorkbook;
-            Workbook w;
-            Cell cell;
-            InputStream in;
-
-            lk.gov.health.phsp.facade.util.JsfUtil.addSuccessMessage(file.getFileName());
-
-            try {
-                lk.gov.health.phsp.facade.util.JsfUtil.addSuccessMessage(file.getFileName());
-                in = file.getInputStream();
-                File f;
-                f = new File(Calendar.getInstance().getTimeInMillis() + file.getFileName());
-                FileOutputStream out = new FileOutputStream(f);
-                Integer read = 0;
-                byte[] bytes = new byte[1024];
-                while ((read = in.read(bytes)) != -1) {
-                    out.write(bytes, 0, read);
-                }
-                in.close();
-                out.flush();
-                out.close();
-
-                inputWorkbook = new File(f.getAbsolutePath());
-
-                successMessage += "File Uploaded Successfully." + newLine;
-
-                w = Workbook.getWorkbook(inputWorkbook);
-                Sheet sheet = w.getSheet(0);
-                int startRow = 1;
-
-                for (Integer i = startRow; i < sheet.getRows(); i++) {
-
-                    Institution newIns = new Institution();
-                    Institution newClinic = new Institution();
-                    String insName;
-                    String poi;
-
-                    cell = sheet.getCell(0, i);
-                    insName = cell.getContents();
-
-                    cell = sheet.getCell(1, i);
-                    poi = cell.getContents();
-
-                    newIns.setPoiNumber(poi);
-                    newIns.setName(institutionType.getLabel() + " " + insName);
-                    newIns.setInstitutionType(institutionType);
-                    newIns.setCreatedAt(new Date());
-                    newIns.setCreater(webUserController.getLoggedUser());
-                    newIns.setDistrict(district);
-                    newIns.setLastHin(0l);
-
-                    newIns.setParent(parent);
-                    newIns.setPdhsArea(pdhsArea);
-                    newIns.setProvince(province);
-                    newIns.setRdhsArea(rdhsArea);
-                    getFacade().create(newIns);
-
-                    newClinic.setName("HLC " + insName);
-                    newClinic.setInstitutionType(InstitutionType.Clinic);
-                    newClinic.setCreatedAt(new Date());
-                    newClinic.setCreater(webUserController.getLoggedUser());
-                    newClinic.setDistrict(district);
-                    newClinic.setLastHin(0l);
-                    newClinic.setPoiInstitution(newIns);
-                    newClinic.setParent(newIns);
-                    newClinic.setPdhsArea(pdhsArea);
-                    newClinic.setProvince(province);
-                    newClinic.setRdhsArea(rdhsArea);
-                    getFacade().create(newClinic);
-
-                    institutionApplicationController.setInstitutions(null);
-
-                }
-                lk.gov.health.phsp.facade.util.JsfUtil.addSuccessMessage("Completed. Please check success and failure messages.");
-                return "";
-            } catch (IOException | BiffException ex) {
-                lk.gov.health.phsp.facade.util.JsfUtil.addErrorMessage(ex.getMessage());
-                failureMessage += "Error. " + ex.getMessage() + ". Aborting the process." + newLine;
-                return "";
-            }
-        } catch (IndexOutOfBoundsException e) {
-            failureMessage += "Error. " + e.getMessage() + ". Aborting the process." + newLine;
+        if (file == null) {
+            JsfUtil.addErrorMessage("No file selected.");
+            return "";
+        }
+        if (institutionType == null) {
+            JsfUtil.addErrorMessage("Please select an Institution Type.");
+            return "";
+        }
+        if (importRunning) {
+            JsfUtil.addErrorMessage("Import already in progress.");
             return "";
         }
 
+        try {
+            InputStream in = file.getInputStream();
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            byte[] buf = new byte[1024];
+            int read;
+            while ((read = in.read(buf)) != -1) {
+                baos.write(buf, 0, read);
+            }
+            in.close();
+
+            importProgress = new int[4];
+            importWarnings = Collections.synchronizedList(new ArrayList<>());
+            importRunningFlag[0] = true;
+            importRunning = true;
+
+            institutionImportService.runImport(
+                    baos.toByteArray(),
+                    webUserController.getLoggedUser().getId(),
+                    institutionType,
+                    parent   != null ? parent.getId()   : null,
+                    province != null ? province.getId() : null,
+                    pdhsArea != null ? pdhsArea.getId() : null,
+                    district != null ? district.getId() : null,
+                    rdhsArea != null ? rdhsArea.getId() : null,
+                    importProgress, importRunningFlag, importWarnings);
+
+            return "";
+        } catch (IOException ex) {
+            importRunning = false;
+            JsfUtil.addErrorMessage(ex.getMessage());
+            failureMessage = "Error reading file: " + ex.getMessage();
+            return "";
+        }
     }
+
+    public boolean isImportRunning() {
+        if (importRunning && !importRunningFlag[0]) {
+            importRunning = false;
+        }
+        return importRunning;
+    }
+
+    public int getImportProcessed() { return importProgress[0]; }
+    public int getImportTotal()     { return importProgress[1]; }
+    public int getImportCreated()   { return importProgress[2]; }
+    public int getImportSkipped()   { return importProgress[3]; }
+
+    public int getImportPercent() {
+        int total = importProgress[1];
+        if (total <= 0) return 0;
+        return (int) Math.min(importProgress[0] * 100L / total, 100);
+    }
+
+    public List<String> getImportWarnings() { return importWarnings; }
     
     public void saveOrUpdateInstitution() {
         if (selected == null) {

--- a/src/main/java/lk/gov/health/phsp/bean/InstitutionImportService.java
+++ b/src/main/java/lk/gov/health/phsp/bean/InstitutionImportService.java
@@ -1,0 +1,157 @@
+package lk.gov.health.phsp.bean;
+
+import java.io.ByteArrayInputStream;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.ejb.Asynchronous;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.inject.Inject;
+import jxl.Cell;
+import jxl.Sheet;
+import jxl.Workbook;
+import lk.gov.health.phsp.entity.Area;
+import lk.gov.health.phsp.entity.Institution;
+import lk.gov.health.phsp.entity.WebUser;
+import lk.gov.health.phsp.enums.InstitutionType;
+import lk.gov.health.phsp.facade.AreaFacade;
+import lk.gov.health.phsp.facade.InstitutionFacade;
+import lk.gov.health.phsp.facade.WebUserFacade;
+
+@Stateless
+public class InstitutionImportService {
+
+    @EJB
+    private InstitutionFacade institutionFacade;
+
+    @EJB
+    private AreaFacade areaFacade;
+
+    @EJB
+    private WebUserFacade webUserFacade;
+
+    @Inject
+    private InstitutionApplicationController institutionApplicationController;
+
+    /**
+     * Async import — no outer transaction; each facade.create() is its own transaction.
+     * Areas and WebUser are looked up by ID inside each create via the facade (REQUIRED).
+     */
+    @Asynchronous
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public void runImport(byte[] fileData,
+                          Long createdById,
+                          InstitutionType institutionType,
+                          Long parentId,
+                          Long provinceId,
+                          Long pdhsAreaId,
+                          Long districtId,
+                          Long rdhsAreaId,
+                          int[] progress,
+                          boolean[] running,
+                          List<String> warnings) {
+        try {
+            // Fetch managed references once (each call is REQUIRED — own transaction)
+            WebUser   createdBy = webUserFacade.find(createdById);
+            Institution parent  = parentId  != null ? institutionFacade.find(parentId)  : null;
+            Area province       = provinceId != null ? areaFacade.find(provinceId)  : null;
+            Area pdhsArea       = pdhsAreaId != null ? areaFacade.find(pdhsAreaId)  : null;
+            Area district       = districtId != null ? areaFacade.find(districtId)  : null;
+            Area rdhsArea       = rdhsAreaId != null ? areaFacade.find(rdhsAreaId)  : null;
+
+            // O(1) duplicate check
+            Set<String> existingNames = new HashSet<>();
+            for (Institution ins : institutionApplicationController.getInstitutions()) {
+                if (ins.getName() != null) {
+                    existingNames.add(ins.getName().toLowerCase());
+                }
+            }
+
+            Workbook w = Workbook.getWorkbook(new ByteArrayInputStream(fileData));
+            Sheet sheet = w.getSheet(0);
+            progress[1] = Math.max(0, sheet.getRows() - 1);
+
+            for (int i = 1; i < sheet.getRows(); i++) {
+                progress[0]++;
+
+                String insName = getCellValue(sheet, 0, i);
+                String poi     = getCellValue(sheet, 1, i);
+
+                if (insName.isEmpty()) {
+                    progress[3]++;
+                    continue;
+                }
+
+                String fullName = institutionType.getLabel() + " " + insName;
+                String hlcName  = "HLC " + insName;
+
+                if (existingNames.contains(fullName.toLowerCase())) {
+                    progress[3]++;
+                    continue;
+                }
+
+                try {
+                    Institution newIns = buildInstitution(
+                            fullName, poi.isEmpty() ? null : poi,
+                            institutionType, createdBy,
+                            parent, province, pdhsArea, district, rdhsArea);
+                    institutionFacade.create(newIns);
+                    existingNames.add(fullName.toLowerCase());
+
+                    Institution newClinic = buildInstitution(
+                            hlcName, null,
+                            InstitutionType.Clinic, createdBy,
+                            newIns, province, pdhsArea, district, rdhsArea);
+                    newClinic.setPoiInstitution(newIns);
+                    institutionFacade.create(newClinic);
+                    existingNames.add(hlcName.toLowerCase());
+
+                    progress[2]++;
+                } catch (Exception ex) {
+                    warnings.add("Row " + i + " (" + insName + "): save failed — " + ex.getMessage());
+                    progress[3]++;
+                }
+            }
+
+        } catch (Exception ex) {
+            warnings.add("Fatal error: " + ex.getMessage());
+        } finally {
+            running[0] = false;
+            try {
+                institutionApplicationController.resetAllInstitutions();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    private Institution buildInstitution(String name, String poi, InstitutionType type,
+                                          WebUser createdBy, Institution parent,
+                                          Area province, Area pdhsArea, Area district, Area rdhsArea) {
+        Institution ins = new Institution();
+        ins.setName(name);
+        ins.setPoiNumber(poi);
+        ins.setInstitutionType(type);
+        ins.setCreatedAt(new Date());
+        ins.setCreater(createdBy);
+        ins.setLastHin(0L);
+        ins.setParent(parent);
+        ins.setProvince(province);
+        ins.setPdhsArea(pdhsArea);
+        ins.setDistrict(district);
+        ins.setRdhsArea(rdhsArea);
+        return ins;
+    }
+
+    private String getCellValue(Sheet sheet, int col, int row) {
+        try {
+            Cell cell = sheet.getCell(col, row);
+            return cell == null ? "" : cell.getContents().trim();
+        } catch (Exception e) {
+            return "";
+        }
+    }
+}

--- a/src/main/webapp/institution/import.xhtml
+++ b/src/main/webapp/institution/import.xhtml
@@ -10,86 +10,119 @@
         <ui:composition template="/institution/index.xhtml">
             <ui:define name="insContents">
 
-                <h:form id="InstitutionCreateForm" style="padding-top: 1rem;"  enctype="multipart/form-data">
+                <!-- Upload form — hidden while import is running -->
+                <h:form enctype="multipart/form-data" rendered="#{!institutionController.importRunning}">
 
-                    <h:panelGroup id="display">
-                        <p:commandButton ajax="false" 
-                                         action="#{institutionController.importInstitutions()}" 
-                                         value="Import"/>
+                    <p:panel header="Instructions" style="margin-bottom:1rem;">
+                        <p>Upload an XLS file with institution names. Column A = Institution Name, Column B = POI Number.</p>
+                        <p>Each row creates one institution of the selected type plus an HLC Clinic linked to it.</p>
+                        <p>Duplicates (matching name) are skipped automatically.</p>
+                    </p:panel>
 
+                    <p:panelGrid columns="2" style="margin-bottom:1rem;">
 
-                        <p>Start Row - 1</p>
-                        <p>Institution Name Column - 1 / A</p><!-- comment -->
-                        <p>POI Column - 2 / B</p>
+                        <p:outputLabel value="File (.xls only)" for="file"/>
+                        <p:fileUpload id="file" value="#{institutionController.file}" mode="simple"/>
 
-                        <p:panelGrid columns="2">
-                            <p:outputLabel value="File" for="file" />
-                            <p:fileUpload id="file" value="#{institutionController.file}" mode="simple"/>
+                        <p:outputLabel value="Type:" for="institutionType"/>
+                        <p:selectOneMenu id="institutionType"
+                                         value="#{institutionController.institutionType}"
+                                         required="true">
+                            <f:selectItems value="#{applicationController.institutionTypes}"
+                                           var="institutionTypes"
+                                           itemValue="#{institutionTypes}"
+                                           itemLabel="#{institutionTypes.label}"/>
+                        </p:selectOneMenu>
 
-                            <p:outputLabel value="Type:" for="institutionType" />
-                            <p:selectOneMenu id="institutionType" 
-                                             value="#{institutionController.institutionType}" title="InstitutionType" 
-                                             required="true" >
-                                <f:selectItems value="#{applicationController.institutionTypes}" 
-                                               var="institutionTypes"
-                                               itemValue="#{institutionTypes}"
+                        <p:outputLabel value="Parent:" for="parent"/>
+                        <p:autoComplete id="parent" value="#{institutionController.parent}"
+                                        required="true"
+                                        completeMethod="#{institutionController.completeInstitutions}"
+                                        var="i" itemLabel="#{i.name}" itemValue="#{i}"
+                                        forceSelection="true" maxResults="15" minQueryLength="3"/>
 
-                                               itemLabel="#{institutionTypes.label}"></f:selectItems>
-                            </p:selectOneMenu>
+                        <p:outputLabel value="Province:" for="province"/>
+                        <p:autoComplete id="province" value="#{institutionController.province}"
+                                        completeMethod="#{areaController.completeProvinces}"
+                                        required="true"
+                                        var="province" itemLabel="#{province.name}" itemValue="#{province}"
+                                        maxResults="15" forceSelection="true" minQueryLength="3"/>
 
+                        <p:outputLabel value="PDHS Area:" for="pdhsArea"/>
+                        <p:autoComplete id="pdhsArea" value="#{institutionController.pdhsArea}"
+                                        completeMethod="#{areaController.completePdhsAreas}"
+                                        required="true"
+                                        var="pdhsArea" itemLabel="#{pdhsArea.name}" itemValue="#{pdhsArea}"
+                                        maxResults="15" forceSelection="true" minQueryLength="3"/>
 
-                            <p:outputLabel value="Parent:" for="parent" />
-                            <p:autoComplete  id="parent" value="#{institutionController.parent}" 
-                                             required="true"
-                                             completeMethod="#{institutionController.completeInstitutions}"
-                                             var="i" itemLabel="#{i.name}" itemValue="#{i}" forceSelection="true"
-                                             maxResults="15" minQueryLength="3">
-                            </p:autoComplete >
+                        <p:outputLabel value="District:" for="district"/>
+                        <p:autoComplete id="district" value="#{institutionController.district}"
+                                        completeMethod="#{areaController.completeDistricts}"
+                                        required="true"
+                                        var="district" itemLabel="#{district.name}" itemValue="#{district}"
+                                        maxResults="15" forceSelection="true" minQueryLength="3"/>
 
+                        <p:outputLabel value="RDHS Area:" for="rdhsArea"/>
+                        <p:autoComplete id="rdhsArea" value="#{institutionController.rdhsArea}"
+                                        completeMethod="#{areaController.completeRdhsAreas}"
+                                        required="true"
+                                        var="rdhsArea" itemLabel="#{rdhsArea.name}" itemValue="#{rdhsArea}"
+                                        maxResults="15" forceSelection="true" minQueryLength="3"/>
 
+                    </p:panelGrid>
 
-                            <p:outputLabel value="Province:" for="province" />
-                            <p:autoComplete id="province" value="#{institutionController.province}"
-                                            completeMethod="#{areaController.completeProvinces}" required="true"
-                                            var="province" itemLabel="#{province.name}" itemValue="#{province}"
-                                            maxResults="15" forceSelection="true"
-                                            minQueryLength="3">
-                            </p:autoComplete>
+                    <p:commandButton ajax="false" value="Import Institutions"
+                                     action="#{institutionController.importInstitutions()}"/>
 
-                            <p:outputLabel value="PDHS Area:" for="pdhsArea" />
-                            <p:autoComplete id="pdhsArea" value="#{institutionController.pdhsArea}"
-                                            completeMethod="#{areaController.completePdhsAreas}"
-                                            required="true"
-                                            var="pdhsArea" itemLabel="#{pdhsArea.name}" itemValue="#{pdhsArea}"
-                                            maxResults="15" forceSelection="true"
-                                            minQueryLength="3">
-                            </p:autoComplete>
-
-                            <p:outputLabel value="District:" for="district" />
-                            <p:autoComplete id="district" value="#{institutionController.district}"
-                                            completeMethod="#{areaController.completeDistricts}"
-                                            required="true"
-                                            var="district" itemLabel="#{district.name}" itemValue="#{district}"
-                                            maxResults="15" forceSelection="true"
-                                            minQueryLength="3">
-                            </p:autoComplete>
-
-                            <p:outputLabel value="RDHS Area:" for="rdhsArea" />
-                            <p:autoComplete id="rdhsArea" value="#{institutionController.rdhsArea}"
-                                            completeMethod="#{areaController.completeRdhsAreas}"
-                                            required="true"
-                                            var="rdhsArea" itemLabel="#{rdhsArea.name}" itemValue="#{rdhsArea}"
-                                            maxResults="15" forceSelection="true"
-                                            minQueryLength="3">
-                            </p:autoComplete>
-
-
-                        </p:panelGrid>                            
-
-                    </h:panelGroup>
+                    <p:panel rendered="#{not empty institutionController.failureMessage}"
+                             header="Error" style="margin-top:1rem;">
+                        <h:outputText value="#{institutionController.failureMessage}" escape="false"/>
+                    </p:panel>
                 </h:form>
+
+                <!-- Progress form — polled every 2 seconds while import runs -->
+                <h:form id="progressForm">
+                    <h:panelGroup id="progressPanel" layout="block">
+                        <p:panel rendered="#{institutionController.importRunning}" style="margin-top:1rem;">
+                            <f:facet name="header">Importing Institutions...</f:facet>
+                            <p:progressBar value="#{institutionController.importPercent}"
+                                           labelTemplate="{value}%"
+                                           style="margin-bottom:0.8rem;"/>
+                            <p>
+                                <strong>Processed:</strong> #{institutionController.importProcessed} of #{institutionController.importTotal} rows
+                            </p>
+                            <p>
+                                <strong>Created:</strong> #{institutionController.importCreated} &#160;
+                                <strong>Skipped:</strong> #{institutionController.importSkipped}
+                            </p>
+                        </p:panel>
+                    </h:panelGroup>
+
+                    <h:panelGroup id="donePanel" layout="block">
+                        <p:panel rendered="#{!institutionController.importRunning and institutionController.importTotal gt 0}"
+                                 style="margin-top:1rem;">
+                            <f:facet name="header">Import Complete</f:facet>
+                            <p style="color:green;">
+                                <strong>Created:</strong> #{institutionController.importCreated} &#160;
+                                <strong>Skipped:</strong> #{institutionController.importSkipped} &#160;
+                                <strong>Total rows processed:</strong> #{institutionController.importProcessed}
+                            </p>
+                            <p:dataList value="#{institutionController.importWarnings}" var="w"
+                                        rendered="#{not empty institutionController.importWarnings}"
+                                        style="color:orange; margin-top:0.5rem;">
+                                <h:outputText value="#{w}"/>
+                            </p:dataList>
+                        </p:panel>
+                    </h:panelGroup>
+
+                    <p:poll id="importPoll"
+                            interval="2"
+                            autoStart="true"
+                            update="progressPanel donePanel"
+                            stop="#{!institutionController.importRunning}"/>
+                </h:form>
+
             </ui:define>
         </ui:composition>
-
     </body>
 </html>

--- a/src/main/webapp/institution/index.xhtml
+++ b/src/main/webapp/institution/index.xhtml
@@ -38,7 +38,11 @@
                                              value="Add Draining GN Areas for Health Institutions" 
                                              action="#{areaController.toImportInstitutionDrainingAreas()}"  ></p:commandButton>
 
-                            <p:commandButton value="Reload Institutions" ajax="false" 
+                            <p:commandButton value="Import Institutions from Excel" ajax="false"
+                                             style="width: 15rem; margin-top:1rem;"
+                                             action="#{institutionController.toImportInstitution()}"></p:commandButton>
+
+                            <p:commandButton value="Reload Institutions" ajax="false"
                                              style="width: 15rem; margin-top:1rem;"
                                              action="#{institutionController.resetAllInstitutions()}">
 


### PR DESCRIPTION
## Summary
Brings the institution Excel-import flow from the (now-stale) #356 onto the current master. The apple-checkbox / multi-select half of #356 was already merged via #359, so this PR carries only the import-related delta.

## What ships
- **`InstitutionImportService.java`** — new `@Stateless` EJB with `@Asynchronous` and `@TransactionAttribute(NOT_SUPPORTED)`. Each row's `create()` is its own transaction, so a single bad row does not roll back the batch. `HashSet` duplicate check for O(1) lookup vs the previous O(n²) loop.
- **`InstitutionController.java`** — dispatches `byte[]` + entity IDs to the EJB to avoid detached-entity issues across the async boundary; exposes `importRunning` / `importPercent` / `importProcessed` / `importTotal` / `importCreated` / `importSkipped` getters for the progress UI.
- **`institution/import.xhtml`** — upload form is hidden while a run is in progress; always-present `<h:panelGroup>` wrappers as AJAX update targets; `<p:poll>` every 2 s with a stop condition tied to `importRunning`.
- **`institution/index.xhtml`** — adds the **Import Institutions from Excel** button next to the existing import controls; targets `institutionController.toImportInstitution()`.

## Why a new PR instead of rebasing #356
PR #356 was 7 commits ahead / 17 behind the current master and conflicted in 6 files (`InstitutionController`, `ItemController`, `area/list.xhtml`, `institution/list.xhtml`, `item/List.xhtml`, `jsfcrud.css`). All six conflicts came from the apple-checkbox / multi-select work, which #359 has already implemented end-to-end on master. Rebasing risked re-breaking the merged `#359` UI. Cherry-picking just the two import commits (`e039a079`, `f57f0d29`) onto a clean branch off `upstream/master` was the cleaner path. #356 is being closed in favour of this PR.

## Test plan
- [ ] Build: `mvn package -DskipTests` succeeds.
- [ ] Open `Institution → Index`: the new **Import Institutions from Excel** button is visible.
- [ ] Click the button, upload a valid `.xlsx`: progress bar advances, processed/total/created/skipped counters update via the 2 s poll.
- [ ] Upload form is hidden while a run is in progress; reappears after completion.
- [ ] Upload an Excel file containing a duplicate institution: skipped count reflects it; existing institutions are not double-created.
- [ ] Upload a file containing a row that throws on `create()`: the surrounding rows still import (no cascade rollback).
- [ ] No regression on the existing area Excel import flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)