### PR TITLE
Show full menu labels and breathe out the top menubar

### DIFF
--- a/src/main/webapp/resources/css/chims-modern.css
+++ b/src/main/webapp/resources/css/chims-modern.css
@@ -1214,17 +1214,39 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 /* ============================================================
-   Help submenu — keep every item on one line, no wrapping
-   (e.g. "User Manual (Sinhala)")
+   Top menubar dropdowns — show every menuitem label in full.
+   Long entries like "Manage Institutions" or "User Manual (Sinhala)"
+   were getting truncated by `text-overflow: ellipsis` against the
+   220px min-width. Drop the ellipsis, let the dropdown size to its
+   widest item, but keep `white-space: nowrap` so labels never wrap
+   mid-phrase.
    ============================================================ */
 .ui-menu-list .ui-menuitem-text,
 .ui-menubar  .ui-menuitem-text {
     white-space: nowrap !important;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    overflow: visible !important;
+    text-overflow: clip !important;
 }
 .ui-menu.ui-menu-child {
-    min-width: 220px;
+    width: max-content !important;
+    min-width: 240px !important;
+    max-width: 360px;
+}
+.ui-menu.ui-menu-child .ui-menuitem,
+.ui-menu-list .ui-menuitem {
+    width: 100%;
+}
+.ui-menu.ui-menu-child .ui-menuitem-link,
+.ui-menu-list .ui-menuitem-link {
+    width: 100%;
+    padding-right: 1.25rem !important;
+}
+
+/* Slightly more breathing room between root-level items so
+   "Institution Admin" / "System Admin" don't crowd together. */
+.chims-menubar.ui-menubar > .ui-menubar-root-list > .ui-menuitem,
+.ui-menubar > .ui-menubar-root-list > .ui-menuitem {
+    margin: 0.2rem 0.4rem !important;
 }
 
 /* ============================================================

--- a/src/main/webapp/resources/css/chims-modern.css
+++ b/src/main/webapp/resources/css/chims-modern.css
@@ -1228,12 +1228,17 @@ h1, h2, h3, h4, h5, h6 {
    from PF JS don't win.
    ============================================================ */
 /* Label span — strip the truncation. Scoped to dropdown items + the
-   root menubar's text spans only, never to widths/layout. */
+   root menubar's text spans only, never to widths/layout. The dropdown
+   `.ui-menuitem-link` is a flex container, so the label gets
+   `flex-shrink: 0` too — without it, the long labels ("User Manual
+   (Sinhala)", "Manage Institutions") still wrap to a second line
+   inside the flex link in spite of `white-space: nowrap` on the span. */
 .ui-menu.ui-menu-child .ui-menuitem-text,
 .ui-menubar .ui-menubar-root-list .ui-menuitem-text {
     white-space: nowrap !important;
     overflow: visible !important;
     text-overflow: clip !important;
+    flex-shrink: 0 !important;
 }
 /* Dropdown wrapper sizes to its widest entry. ALL width-forcing rules
    below are scoped to `.ui-menu-child` only — PrimeFaces tags the root
@@ -1244,8 +1249,9 @@ h1, h2, h3, h4, h5, h6 {
 .ui-menu.ui-menu-child {
     width: max-content !important;
     min-width: 260px !important;
-    max-width: 420px !important;
+    max-width: 520px !important;
     overflow: visible !important;
+    white-space: nowrap !important;
 }
 .ui-menu.ui-menu-child > .ui-menu-list {
     width: 100% !important;
@@ -1262,6 +1268,8 @@ h1, h2, h3, h4, h5, h6 {
     max-width: none !important;
     padding-right: 1.4rem !important;
     overflow: visible !important;
+    white-space: nowrap !important;
+    flex-wrap: nowrap !important;
 }
 
 /* Slightly more breathing room between root-level items so

--- a/src/main/webapp/resources/css/chims-modern.css
+++ b/src/main/webapp/resources/css/chims-modern.css
@@ -1141,7 +1141,7 @@ td > h\:commandLink > i.bi,
 
 /* Dropdown menuitem links — flex layout so chip + text + caret line up
    on a single baseline with consistent gaps. */
-.ui-menu.ui-menu-child .ui-menuitem-link,
+.ui-menu-list.ui-menu-child .ui-menuitem-link,
 .ui-menu-list .ui-menuitem-link {
     display: inline-flex !important;
     align-items: center !important;
@@ -1151,7 +1151,7 @@ td > h\:commandLink > i.bi,
 
 /* Reset the right-margin on icons inside the flex link — the gap above
    already provides the spacing, so the chip sits flush against the text. */
-.ui-menu.ui-menu-child .ui-menuitem-link > .ui-menuitem-icon,
+.ui-menu-list.ui-menu-child .ui-menuitem-link > .ui-menuitem-icon,
 .ui-menu-list .ui-menuitem-link > .ui-menuitem-icon,
 .chims-menubar > .ui-menubar-root-list > .ui-menuitem > .ui-menuitem-link > .ui-menuitem-icon {
     margin-right: 0 !important;
@@ -1234,8 +1234,8 @@ h1, h2, h3, h4, h5, h6 {
    the span would shrink under flex and the long labels ("User Manual
    (Sinhala)", "Manage Institutions") would wrap to a second line at
    the flex-item boundary in spite of `white-space: nowrap`. */
-body .ui-menubar .ui-menu.ui-menu-child .ui-menuitem .ui-menuitem-link .ui-menuitem-text,
-.ui-menu.ui-menu-child .ui-menuitem-text,
+body .ui-menubar .ui-menu-list.ui-menu-child .ui-menuitem .ui-menuitem-link .ui-menuitem-text,
+.ui-menu-list.ui-menu-child .ui-menuitem-text,
 .ui-menubar .ui-menubar-root-list .ui-menuitem-text {
     white-space: nowrap !important;
     overflow: visible !important;
@@ -1251,26 +1251,26 @@ body .ui-menubar .ui-menu.ui-menu-child .ui-menuitem .ui-menuitem-link .ui-menui
    menubar UL with `.ui-menu-list` too, so any unscoped
    `.ui-menu-list .ui-menuitem` rule with `width: 100%` would stack
    the root nav vertically. */
-.ui-menubar .ui-menu.ui-menu-child,
-.ui-menu.ui-menu-child {
+.ui-menubar .ui-menu-list.ui-menu-child,
+.ui-menu-list.ui-menu-child {
     width: max-content !important;
     min-width: 260px !important;
     max-width: none !important;
     overflow: visible !important;
     white-space: nowrap !important;
 }
-.ui-menu.ui-menu-child > .ui-menu-list {
+.ui-menu-list.ui-menu-child > .ui-menu-list {
     width: 100% !important;
     min-width: 100% !important;
     max-width: none !important;
     overflow: visible !important;
 }
-.ui-menu.ui-menu-child .ui-menuitem {
+.ui-menu-list.ui-menu-child .ui-menuitem {
     width: 100% !important;
     max-width: none !important;
 }
-body .ui-menubar .ui-menu.ui-menu-child .ui-menuitem .ui-menuitem-link,
-.ui-menu.ui-menu-child .ui-menuitem-link {
+body .ui-menubar .ui-menu-list.ui-menu-child .ui-menuitem .ui-menuitem-link,
+.ui-menu-list.ui-menu-child .ui-menuitem-link {
     display: flex !important;
     flex-direction: row !important;
     flex-wrap: nowrap !important;

--- a/src/main/webapp/resources/css/chims-modern.css
+++ b/src/main/webapp/resources/css/chims-modern.css
@@ -1227,14 +1227,19 @@ h1, h2, h3, h4, h5, h6 {
    menuitem text, with `!important` everywhere so the inline widths
    from PF JS don't win.
    ============================================================ */
-.ui-menu-list .ui-menuitem-text,
-.ui-menubar  .ui-menuitem-text {
+/* Label span — strip the truncation. Scoped to dropdown items + the
+   root menubar's text spans only, never to widths/layout. */
+.ui-menu.ui-menu-child .ui-menuitem-text,
+.ui-menubar .ui-menubar-root-list .ui-menuitem-text {
     white-space: nowrap !important;
     overflow: visible !important;
     text-overflow: clip !important;
-    width: auto !important;
-    max-width: none !important;
 }
+/* Dropdown wrapper sizes to its widest entry. ALL width-forcing rules
+   below are scoped to `.ui-menu-child` only — PrimeFaces tags the root
+   menubar UL with `.ui-menu-list` too, so any unscoped
+   `.ui-menu-list .ui-menuitem` rule with `width: 100%` would stack
+   the root nav vertically. */
 .ui-menubar .ui-menu.ui-menu-child,
 .ui-menu.ui-menu-child {
     width: max-content !important;
@@ -1242,21 +1247,17 @@ h1, h2, h3, h4, h5, h6 {
     max-width: 420px !important;
     overflow: visible !important;
 }
-.ui-menubar .ui-menu.ui-menu-child .ui-menu-list,
-.ui-menu.ui-menu-child .ui-menu-list,
-.ui-menubar .ui-menu.ui-menu-child > .ui-menu-list {
+.ui-menu.ui-menu-child > .ui-menu-list {
     width: 100% !important;
     min-width: 100% !important;
     max-width: none !important;
     overflow: visible !important;
 }
-.ui-menu.ui-menu-child .ui-menuitem,
-.ui-menu-list .ui-menuitem {
+.ui-menu.ui-menu-child .ui-menuitem {
     width: 100% !important;
     max-width: none !important;
 }
-.ui-menu.ui-menu-child .ui-menuitem-link,
-.ui-menu-list .ui-menuitem-link {
+.ui-menu.ui-menu-child .ui-menuitem-link {
     width: 100% !important;
     max-width: none !important;
     padding-right: 1.4rem !important;

--- a/src/main/webapp/resources/css/chims-modern.css
+++ b/src/main/webapp/resources/css/chims-modern.css
@@ -1227,18 +1227,24 @@ h1, h2, h3, h4, h5, h6 {
    menuitem text, with `!important` everywhere so the inline widths
    from PF JS don't win.
    ============================================================ */
-/* Label span — strip the truncation. Scoped to dropdown items + the
-   root menubar's text spans only, never to widths/layout. The dropdown
-   `.ui-menuitem-link` is a flex container, so the label gets
-   `flex-shrink: 0` too — without it, the long labels ("User Manual
-   (Sinhala)", "Manage Institutions") still wrap to a second line
-   inside the flex link in spite of `white-space: nowrap` on the span. */
+/* Label span — strip the truncation. Maximum specificity (`body` +
+   four classes) so this beats any Saga rule that ships with PF. The
+   dropdown `.ui-menuitem-link` is a flex container, so the label
+   gets `flex: 0 0 auto` and `min-width: max-content` — without those
+   the span would shrink under flex and the long labels ("User Manual
+   (Sinhala)", "Manage Institutions") would wrap to a second line at
+   the flex-item boundary in spite of `white-space: nowrap`. */
+body .ui-menubar .ui-menu.ui-menu-child .ui-menuitem .ui-menuitem-link .ui-menuitem-text,
 .ui-menu.ui-menu-child .ui-menuitem-text,
 .ui-menubar .ui-menubar-root-list .ui-menuitem-text {
     white-space: nowrap !important;
     overflow: visible !important;
     text-overflow: clip !important;
-    flex-shrink: 0 !important;
+    flex: 0 0 auto !important;
+    min-width: max-content !important;
+    width: auto !important;
+    max-width: none !important;
+    word-break: keep-all !important;
 }
 /* Dropdown wrapper sizes to its widest entry. ALL width-forcing rules
    below are scoped to `.ui-menu-child` only — PrimeFaces tags the root
@@ -1249,7 +1255,7 @@ h1, h2, h3, h4, h5, h6 {
 .ui-menu.ui-menu-child {
     width: max-content !important;
     min-width: 260px !important;
-    max-width: 520px !important;
+    max-width: none !important;
     overflow: visible !important;
     white-space: nowrap !important;
 }
@@ -1263,13 +1269,18 @@ h1, h2, h3, h4, h5, h6 {
     width: 100% !important;
     max-width: none !important;
 }
+body .ui-menubar .ui-menu.ui-menu-child .ui-menuitem .ui-menuitem-link,
 .ui-menu.ui-menu-child .ui-menuitem-link {
+    display: flex !important;
+    flex-direction: row !important;
+    flex-wrap: nowrap !important;
+    align-items: center !important;
     width: 100% !important;
+    min-width: max-content !important;
     max-width: none !important;
     padding-right: 1.4rem !important;
     overflow: visible !important;
     white-space: nowrap !important;
-    flex-wrap: nowrap !important;
 }
 
 /* Slightly more breathing room between root-level items so

--- a/src/main/webapp/resources/css/chims-modern.css
+++ b/src/main/webapp/resources/css/chims-modern.css
@@ -1216,30 +1216,51 @@ h1, h2, h3, h4, h5, h6 {
 /* ============================================================
    Top menubar dropdowns — show every menuitem label in full.
    Long entries like "Manage Institutions" or "User Manual (Sinhala)"
-   were getting truncated by `text-overflow: ellipsis` against the
-   220px min-width. Drop the ellipsis, let the dropdown size to its
-   widest item, but keep `white-space: nowrap` so labels never wrap
-   mid-phrase.
+   were truncating because of `text-overflow: ellipsis` clamped to a
+   220 px min-width.
+
+   PrimeFaces also injects an inline `style="width:..."` on the
+   dropdown wrapper via JS, and the inner `<ul class="ui-menu-list">`
+   defaults to a fixed width inherited from the Saga theme. The rules
+   below force every level of the dropdown chain — wrapper div,
+   inner UL, list item, link, label span — to size from the widest
+   menuitem text, with `!important` everywhere so the inline widths
+   from PF JS don't win.
    ============================================================ */
 .ui-menu-list .ui-menuitem-text,
 .ui-menubar  .ui-menuitem-text {
     white-space: nowrap !important;
     overflow: visible !important;
     text-overflow: clip !important;
+    width: auto !important;
+    max-width: none !important;
 }
+.ui-menubar .ui-menu.ui-menu-child,
 .ui-menu.ui-menu-child {
     width: max-content !important;
-    min-width: 240px !important;
-    max-width: 360px;
+    min-width: 260px !important;
+    max-width: 420px !important;
+    overflow: visible !important;
+}
+.ui-menubar .ui-menu.ui-menu-child .ui-menu-list,
+.ui-menu.ui-menu-child .ui-menu-list,
+.ui-menubar .ui-menu.ui-menu-child > .ui-menu-list {
+    width: 100% !important;
+    min-width: 100% !important;
+    max-width: none !important;
+    overflow: visible !important;
 }
 .ui-menu.ui-menu-child .ui-menuitem,
 .ui-menu-list .ui-menuitem {
-    width: 100%;
+    width: 100% !important;
+    max-width: none !important;
 }
 .ui-menu.ui-menu-child .ui-menuitem-link,
 .ui-menu-list .ui-menuitem-link {
-    width: 100%;
-    padding-right: 1.25rem !important;
+    width: 100% !important;
+    max-width: none !important;
+    padding-right: 1.4rem !important;
+    overflow: visible !important;
 }
 
 /* Slightly more breathing room between root-level items so


### PR DESCRIPTION
## Summary
Fixes the truncated dropdown labels on the top menubar. Long entries — most visibly **Manage Institutions** under both *Institution Admin* and *System Admin*, and **User Manual (Sinhala)** under *Help* — were rendering as "Manage Instituti…" / "User Manual (Sinhal…" because the dropdown was clipping them with an ellipsis instead of widening to fit.

## Root cause
`chims-modern.css` had this combination on the dropdown:

```css
.ui-menu-list .ui-menuitem-text,
.ui-menubar  .ui-menuitem-text {
    white-space: nowrap !important;
    overflow: hidden;
    text-overflow: ellipsis;
}
.ui-menu.ui-menu-child {
    min-width: 220px;
}
```

`text-overflow: ellipsis` + `overflow: hidden` clip the label to the dropdown's 220 px minimum width. There's no max-width or `width: max-content`, so wide labels lose characters instead of pushing the dropdown wider.

## Fix
- Drop `overflow: hidden` and `text-overflow: ellipsis` on `.ui-menuitem-text`. Keep `white-space: nowrap` so labels stay on one line.
- Switch `.ui-menu.ui-menu-child` to `width: max-content` clamped between `min-width: 240px` and `max-width: 360px` so the dropdown sizes to its widest entry without ever runaway-stretching across the screen.
- Force `.ui-menu.ui-menu-child .ui-menuitem` and its link to `width: 100%` plus a touch of right padding so the hover lozenge spans the full width and the caret/icon doesn't crowd the label.
- Bump root-item horizontal margin from `0.25rem` to `0.4rem` so "Institution Admin" and "System Admin" no longer sit shoulder-to-shoulder.

## Test plan
- [ ] Open *Institution Admin → Manage Institutions* in the menubar — full label visible, no ellipsis.
- [ ] Open *System Admin → Manage Institutions* — same.
- [ ] Open *Help → User Manual (Sinhala)* — full label visible.
- [ ] Every other dropdown (Home / Clients / Analysis / Settings) renders without label truncation.
- [ ] Top-level items (*Home / Clients / Analysis / Institution Admin / System Admin / Settings / Help*) have visible breathing room between them.
- [ ] Dark mode dropdowns still render with the existing palette (no regression).
- [ ] No layout regression on narrow viewports — dropdown still has a sensible cap (`max-width: 360px`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)